### PR TITLE
fix: return explicit busy error during LUAD batch embedding contention

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1225,11 +1225,28 @@ function HomePage() {
                               errorMessage.toLowerCase().includes("patch") ||
                               errorMessage.toLowerCase().includes("timeout");
       
+      const lowerError = errorMessage.toLowerCase();
+
+      // Busy overload contract from backend while batch embedding is active
+      const isServerBusy =
+        lowerError.includes("server_busy") ||
+        lowerError.includes("batch embedding") ||
+        lowerError.includes("temporarily unavailable to avoid gpu contention");
+
       // Check if it's a level 0 embeddings required error
-      const needsLevel0 = errorMessage.toLowerCase().includes("level0_embeddings_required") ||
-                          errorMessage.toLowerCase().includes("level 0");
-      
-      if (needsLevel0) {
+      const needsLevel0 = lowerError.includes("level0_embeddings_required") ||
+                          lowerError.includes("level 0");
+
+      if (isServerBusy) {
+        const busyMsg =
+          "Level 0 batch embedding is currently running. Multi-model analysis is temporarily paused to keep the server stable.\n\n" +
+          "Please wait for embedding to finish (or cancel the batch job) and try again.";
+        setMultiModelError(busyMsg);
+        toast.warning(
+          "Server Busy",
+          "Batch embedding is in progress. Please retry analysis in a moment."
+        );
+      } else if (needsLevel0) {
         setMultiModelError(
           "Level 0 embeddings are required for full-resolution analysis. Please click 'Generate Level 0 Embeddings' first."
         );

--- a/tests/test_issue56_batch_embed_contention.py
+++ b/tests/test_issue56_batch_embed_contention.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_backend_analyze_multi_returns_server_busy_contract_when_batch_embed_active():
+    src = _read("src/enso_atlas/api/main.py")
+
+    assert "active_batch_embedding = _active_batch_embed_info()" in src
+    assert '"error": "SERVER_BUSY"' in src
+    assert 'headers={"Retry-After": "30"}' in src
+
+
+def test_health_endpoint_exposes_active_batch_embed_and_uses_cached_cuda_probe():
+    src = _read("src/enso_atlas/api/main.py")
+
+    assert "_CUDA_AVAILABLE_AT_STARTUP" in src
+    assert '"cuda_available": bool(_CUDA_AVAILABLE_AT_STARTUP)' in src
+    assert '"active_batch_embedding": active_batch_embedding' in src
+
+
+def test_frontend_parses_fastapi_detail_shape_and_shows_busy_message():
+    api_src = _read("frontend/src/lib/api.ts")
+    page_src = _read("frontend/src/app/page.tsx")
+
+    assert "const detail = rawError?.detail;" in api_src
+    assert "if (detail && typeof detail === \"object\")" in api_src
+    assert "const isServerBusy =" in page_src
+    assert "lowerError.includes(\"server_busy\")" in page_src


### PR DESCRIPTION
## Summary
- add admission control to `POST /api/analyze-multi` to fail fast with `503` + structured `SERVER_BUSY` payload when a level-0 batch embedding task is active
- include `Retry-After: 30` header and active batch task metadata for actionable client behavior
- make `/health` cheaper under load by using startup-cached CUDA probe and exposing `active_batch_embedding`
- improve frontend API error normalization for FastAPI `detail` responses so structured backend errors surface correctly
- show explicit "Server Busy" UX copy in multi-model analysis flow when batch embedding contention is detected

Fixes Hilo-Hilo/med-gemma-hackathon#56

## Testing
- `python3 -m compileall -q src/enso_atlas/api/main.py src/enso_atlas/api/batch_embed_tasks.py`
- `python3 - <<'PY' ...` (executed string-assertion regression checks from:
  - `tests/test_issue56_batch_embed_contention.py`
  - `tests/test_backend_project_scoping_regressions.py`)

## Notes
- `python3 -m pytest ...` could not be run in this environment because `pytest` is not installed.
- `npm -C frontend run lint ...` could not run because `next` is unavailable in PATH (frontend deps not installed in this runner).