### PR TITLE
fix: align LUAD level0 embedding routing and model selection pruning

### DIFF
--- a/frontend/src/components/panels/ModelPicker.tsx
+++ b/frontend/src/components/panels/ModelPicker.tsx
@@ -232,6 +232,25 @@ export function ModelPicker({
     return [primary, ...unique.filter((m) => m.id !== primary.id)];
   }, [apiModelDetails, projectModelIds, fallbackModels, currentProject]);
 
+  // Prune stale/duplicate selected model IDs whenever the project model list changes.
+  // This prevents impossible counts like 4/3 after project switches.
+  useEffect(() => {
+    if (models.length === 0 || selectedModels.length === 0) return;
+
+    const availableModelIds = new Set(models.map((m) => m.id));
+    const seen = new Set<string>();
+    const prunedSelection = selectedModels.filter((id) => {
+      if (!availableModelIds.has(id)) return false;
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+
+    if (prunedSelection.length !== selectedModels.length) {
+      onSelectionChange(prunedSelection);
+    }
+  }, [models, selectedModels, onSelectionChange]);
+
   // Auto-select all models when models are loaded and selectedModels is empty
   useEffect(() => {
     if (models.length > 0 && selectedModels.length === 0) {

--- a/src/enso_atlas/api/main.py
+++ b/src/enso_atlas/api/main.py
@@ -715,6 +715,72 @@ def create_app(
             )
         return proj_emb_dir
 
+    def _candidate_embedding_dirs_for_level(
+        base_embeddings_dir: Path,
+        *,
+        level: int,
+        project_id: Optional[str],
+    ) -> list[Path]:
+        """Resolve candidate embedding directories for a request.
+
+        Level 0 is strict dense-only: we only check explicit ``level0`` directories
+        (project-level and global-level). We intentionally do not fall back to flat
+        project embedding roots for level 0 because those roots may contain sparse
+        embeddings, which causes silent dense/sparse mismatches.
+        """
+        project_requested = project_id is not None
+        candidates: list[Path] = []
+
+        def _add(path: Path):
+            if path not in candidates:
+                candidates.append(path)
+
+        if level == 0:
+            if base_embeddings_dir.name == "level0":
+                _add(base_embeddings_dir)
+            else:
+                _add(base_embeddings_dir / "level0")
+
+            global_level0 = embeddings_dir if embeddings_dir.name == "level0" else embeddings_dir / "level0"
+            _add(global_level0)
+            _add(_data_root / "embeddings" / "level0")
+        else:
+            _add(base_embeddings_dir)
+            if base_embeddings_dir.name != "level1":
+                _add(base_embeddings_dir / "level1")
+
+            if not project_requested:
+                _add(embeddings_dir)
+                _add(_data_root / "embeddings" / "level1")
+
+        return candidates
+
+    def _resolve_embedding_path(
+        slide_id: str,
+        *,
+        level: int,
+        project_id: Optional[str],
+        base_embeddings_dir: Optional[Path] = None,
+    ) -> tuple[Optional[Path], list[Path]]:
+        """Return (embedding_path, searched_dirs) for a slide-level request."""
+        project_requested = project_id is not None
+        resolved_base = base_embeddings_dir or _resolve_project_embeddings_dir(
+            project_id,
+            require_exists=project_requested,
+        )
+        candidate_dirs = _candidate_embedding_dirs_for_level(
+            resolved_base,
+            level=level,
+            project_id=project_id,
+        )
+
+        for d in candidate_dirs:
+            emb_path = d / f"{slide_id}.npy"
+            if emb_path.exists():
+                return emb_path, candidate_dirs
+
+        return None, candidate_dirs
+
     def _resolve_project_label_pair(
         project_id: Optional[str],
         *,
@@ -2049,29 +2115,13 @@ def create_app(
 
         def _resolve_emb_path(slide_id: str):
             """Resolve embedding path based on requested level and project scope."""
-            candidate_dirs: List[Path] = []
-            if level == 0:
-                if batch_embeddings_dir.name == "level0":
-                    candidate_dirs.append(batch_embeddings_dir)
-                else:
-                    candidate_dirs.extend([batch_embeddings_dir / "level0", batch_embeddings_dir])
-                if not project_requested and batch_embeddings_dir != embeddings_dir:
-                    if embeddings_dir.name == "level0":
-                        candidate_dirs.append(embeddings_dir)
-                    else:
-                        candidate_dirs.extend([embeddings_dir / "level0", embeddings_dir])
-            else:
-                candidate_dirs.append(batch_embeddings_dir)
-                if batch_embeddings_dir.name != "level1":
-                    candidate_dirs.append(batch_embeddings_dir / "level1")
-                if not project_requested and batch_embeddings_dir != embeddings_dir:
-                    candidate_dirs.extend([embeddings_dir, embeddings_dir / "level1"])
-
-            for d in candidate_dirs:
-                p = d / f"{slide_id}.npy"
-                if p.exists():
-                    return p
-            return None
+            emb_path, _ = _resolve_embedding_path(
+                slide_id,
+                level=level,
+                project_id=project_id,
+                base_embeddings_dir=batch_embeddings_dir,
+            )
+            return emb_path
 
         def analyze_single_slide(slide_id: str) -> BatchSlideResult:
             """Analyze a single slide and return result."""
@@ -3692,11 +3742,27 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
             require_exists=project_requested,
         )
 
-        emb_path = _heatmap_embeddings_dir / f"{slide_id}.npy"
-        coord_path = _heatmap_embeddings_dir / f"{slide_id}_coords.npy"
+        emb_path, searched_dirs = _resolve_embedding_path(
+            slide_id,
+            level=0,
+            project_id=project_id,
+            base_embeddings_dir=_heatmap_embeddings_dir,
+        )
+        if emb_path is None:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "LEVEL0_EMBEDDINGS_REQUIRED",
+                    "message": f"Level 0 (full resolution) embeddings do not exist for slide {slide_id}. Generate embeddings first using /api/embed-slide with level=0.",
+                    "needs_embedding": True,
+                    "slide_id": slide_id,
+                    "level": 0,
+                    "project_id": project_id,
+                    "searched_dirs": [str(d) for d in searched_dirs],
+                },
+            )
 
-        if not emb_path.exists():
-            raise HTTPException(status_code=404, detail=f"Slide {slide_id} not found")
+        coord_path = emb_path.with_name(f"{slide_id}_coords.npy")
 
         embeddings = np.load(emb_path)
 
@@ -5930,26 +5996,15 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
             require_exists=project_requested,
         )
 
-        emb_path: Optional[Path] = None
-        if level == 0:
-            candidate_dirs = []
-            if analysis_embeddings_dir.name == "level0":
-                candidate_dirs.append(analysis_embeddings_dir)
-            else:
-                candidate_dirs.extend([analysis_embeddings_dir / "level0", analysis_embeddings_dir])
-            if not project_requested:
-                if embeddings_dir.name == "level0":
-                    candidate_dirs.append(embeddings_dir)
-                else:
-                    candidate_dirs.extend([embeddings_dir / "level0", embeddings_dir])
+        emb_path, searched_dirs = _resolve_embedding_path(
+            slide_id,
+            level=level,
+            project_id=request.project_id,
+            base_embeddings_dir=analysis_embeddings_dir,
+        )
 
-            for d in candidate_dirs:
-                cand = d / f"{slide_id}.npy"
-                if cand.exists():
-                    emb_path = cand
-                    break
-
-            if emb_path is None:
+        if emb_path is None:
+            if level == 0:
                 raise HTTPException(
                     status_code=400,
                     detail={
@@ -5959,25 +6014,9 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
                         "slide_id": slide_id,
                         "level": 0,
                         "project_id": request.project_id,
+                        "searched_dirs": [str(d) for d in searched_dirs],
                     }
                 )
-        else:
-            candidate_dirs = [analysis_embeddings_dir]
-            if analysis_embeddings_dir.name != "level1":
-                candidate_dirs.append(analysis_embeddings_dir / "level1")
-            if not project_requested:
-                candidate_dirs.extend([
-                    embeddings_dir,
-                    _data_root / "embeddings" / "level1",
-                ])
-
-            for d in candidate_dirs:
-                cand = d / f"{slide_id}.npy"
-                if cand.exists():
-                    emb_path = cand
-                    break
-
-        if emb_path is None or not emb_path.exists():
             raise HTTPException(status_code=404, detail=f"Slide {slide_id} not found")
 
         embeddings = np.load(emb_path)
@@ -6125,11 +6164,27 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
                 },
             )
 
-        emb_path = _model_heatmap_embeddings_dir / f"{slide_id}.npy"
-        coord_path = _model_heatmap_embeddings_dir / f"{slide_id}_coords.npy"
+        emb_path, searched_dirs = _resolve_embedding_path(
+            slide_id,
+            level=0,
+            project_id=project_id,
+            base_embeddings_dir=_model_heatmap_embeddings_dir,
+        )
+        if emb_path is None:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "LEVEL0_EMBEDDINGS_REQUIRED",
+                    "message": f"Level 0 (full resolution) embeddings do not exist for slide {slide_id}. Generate embeddings first using /api/embed-slide with level=0.",
+                    "needs_embedding": True,
+                    "slide_id": slide_id,
+                    "level": 0,
+                    "project_id": project_id,
+                    "searched_dirs": [str(d) for d in searched_dirs],
+                },
+            )
 
-        if not emb_path.exists():
-            raise HTTPException(status_code=404, detail=f"Slide {slide_id} not found")
+        coord_path = emb_path.with_name(f"{slide_id}_coords.npy")
 
         # Coordinates are required for truthful attention localization.
         # Synthetic fallback grids create misleading overlays when embeddings were
@@ -6148,7 +6203,7 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
         # Check disk cache first (only for default alpha_power).
         # Use a versioned cache key to avoid serving stale overlays generated
         # with pre-fix coordinate assumptions.
-        cache_dir = _model_heatmap_embeddings_dir / "heatmap_cache"
+        cache_dir = emb_path.parent / "heatmap_cache"
         cache_dir.mkdir(exist_ok=True)
         is_default_alpha = abs(alpha_power - 0.7) < 0.01
         cache_suffix = project_id if project_id else "global"

--- a/tests/test_issue55_luad_regressions.py
+++ b/tests/test_issue55_luad_regressions.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_model_picker_prunes_stale_model_ids_after_project_switch():
+    src = _read("frontend/src/components/panels/ModelPicker.tsx")
+
+    assert "Prune stale/duplicate selected model IDs" in src
+    assert "const availableModelIds = new Set(models.map((m) => m.id));" in src
+    assert "if (prunedSelection.length !== selectedModels.length)" in src
+
+
+def test_level0_embedding_resolution_is_dense_only_no_sparse_fallback():
+    src = _read("src/enso_atlas/api/main.py")
+
+    assert "def _candidate_embedding_dirs_for_level(" in src
+    assert "Level 0 is strict dense-only" in src
+    assert "candidate_dirs.extend([analysis_embeddings_dir / \"level0\", analysis_embeddings_dir])" not in src
+    assert "candidate_dirs.extend([batch_embeddings_dir / \"level0\", batch_embeddings_dir])" not in src
+
+
+def test_heatmap_and_multi_model_paths_share_level0_embedding_resolver():
+    src = _read("src/enso_atlas/api/main.py")
+
+    assert src.count("emb_path, searched_dirs = _resolve_embedding_path(") >= 3
+    assert "coord_path = emb_path.with_name(f\"{slide_id}_coords.npy\")" in src
+    assert src.count('"error": "LEVEL0_EMBEDDINGS_REQUIRED"') >= 3


### PR DESCRIPTION
## Summary
- prune stale/duplicate selected model IDs in `ModelPicker` when project model lists change, preventing impossible counts like `4/3` and invalid cross-project model carryover
- centralize embedding path resolution with strict dense-only level0 routing to avoid silently using sparse project-root embeddings
- update slide heatmap and model heatmap endpoints to use the shared level0 resolver and return explicit `LEVEL0_EMBEDDINGS_REQUIRED` details when dense assets are missing
- align async batch and multi-model analysis embedding lookup with the same resolver behavior
- add focused regression tests for issue #55 covering frontend pruning and backend level0 path policy

## Testing
- `python3 -m py_compile src/enso_atlas/api/main.py`
- ran regression test functions directly (pytest unavailable in this environment):
  - `tests/test_issue55_luad_regressions.py` (3 passed)
  - `tests/test_backend_project_scoping_regressions.py` (5 passed)
  - `tests/test_frontend_heatmap_proxy_scoping.py` (3 passed)

Fixes Hilo-Hilo/med-gemma-hackathon#55