### PR TITLE
fix: enforce level-0 dense embeddings as default analysis path

### DIFF
--- a/frontend/src/components/panels/BatchAnalysisPanel.tsx
+++ b/frontend/src/components/panels/BatchAnalysisPanel.tsx
@@ -152,7 +152,7 @@ export function BatchAnalysisPanel({
 
   // Model selection state
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
-  const [resolutionLevel, setResolutionLevel] = useState(1);
+  const [resolutionLevel, setResolutionLevel] = useState(0);
   const [forceReembed, setForceReembed] = useState(false);
   const [modelConfigExpanded, setModelConfigExpanded] = useState(true);
   const [apiModelDetails, setApiModelDetails] = useState<AvailableModelDetail[]>([]);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2395,7 +2395,7 @@ export async function startBatchAnalysisAsync(
         slide_ids: slideIds,
         concurrency,
         model_ids: options?.modelIds ?? null,
-        level: options?.level ?? 1,
+        level: options?.level ?? 0,
         force_reembed: options?.forceReembed ?? false,
       }),
     }


### PR DESCRIPTION
## Summary
- defaulted analysis request models and frontend batch analysis calls to level 0 so dense/full-resolution is the default path
- tightened `/api/analyze-multi` embedding lookup to level-0 directories only (removed legacy non-level0 fallback lookup)
- updated `/api/embed-slide` default request level to 0 and removed legacy level-1 existence shortcut
- ensured embed extraction loops include the full 224x224 grid boundary (`+1` range end) in single-slide, inline, and batch embedding flows

## Testing
- `python3 -m py_compile src/enso_atlas/api/main.py`
- `npm --prefix frontend run lint -- --file src/lib/api.ts --file src/components/panels/BatchAnalysisPanel.tsx` *(fails in this environment: `next: command not found`)*
- `pytest -q` *(fails in this environment: `pytest: command not found`)*