### PR TITLE
fix: add optional interpolated mode for sparse LUAD heatmaps

### DIFF
--- a/frontend/src/app/api/heatmap/[slideId]/[modelId]/route.ts
+++ b/frontend/src/app/api/heatmap/[slideId]/[modelId]/route.ts
@@ -16,9 +16,11 @@ export async function GET(
     const backendParams = new URLSearchParams();
     const level = searchParams.get("level");
     const alphaPower = searchParams.get("alpha_power");
+    const smooth = searchParams.get("smooth");
     const projectId = searchParams.get("project_id");
     if (level) backendParams.set("level", level);
     if (alphaPower) backendParams.set("alpha_power", alphaPower);
+    if (smooth) backendParams.set("smooth", smooth);
     if (projectId) backendParams.set("project_id", projectId);
     const qs = backendParams.toString() ? `?${backendParams.toString()}` : "";
     const backendUrl = `${BACKEND_URL}/api/heatmap/${encodeURIComponent(slideId)}/${encodeURIComponent(modelId)}${qs}`;
@@ -39,7 +41,7 @@ export async function GET(
     
     const headers: Record<string, string> = {
       "Content-Type": contentType,
-      "Cache-Control": alphaPower ? "no-cache" : "public, max-age=3600",
+      "Cache-Control": alphaPower || smooth ? "no-cache" : "public, max-age=3600",
     };
     // Forward coverage headers for heatmap alignment
     for (const h of ["X-Model-Id", "X-Model-Name", "X-Slide-Width", "X-Slide-Height", "X-Coverage-Width", "X-Coverage-Height"]) {

--- a/frontend/src/app/api/heatmap/[slideId]/route.ts
+++ b/frontend/src/app/api/heatmap/[slideId]/route.ts
@@ -13,12 +13,14 @@ export async function GET(
   const { searchParams } = new URL(request.url);
   const level = searchParams.get("level");
   const alphaPower = searchParams.get("alpha_power");
+  const smooth = searchParams.get("smooth");
   const projectId = searchParams.get("project_id");
   
   try {
     const backendParams = new URLSearchParams();
     if (level) backendParams.set("level", level);
     if (alphaPower) backendParams.set("alpha_power", alphaPower);
+    if (smooth) backendParams.set("smooth", smooth);
     if (projectId) backendParams.set("project_id", projectId);
 
     const qs = backendParams.toString() ? `?${backendParams.toString()}` : "";
@@ -40,7 +42,7 @@ export async function GET(
 
     const headers: Record<string, string> = {
       "Content-Type": contentType,
-      "Cache-Control": alphaPower ? "no-cache" : "public, max-age=3600",
+      "Cache-Control": alphaPower || smooth ? "no-cache" : "public, max-age=3600",
     };
 
     for (const h of ["X-Slide-Width", "X-Slide-Height", "X-Coverage-Width", "X-Coverage-Height"]) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -334,6 +334,7 @@ function HomePage() {
   const [heatmapModel, setHeatmapModel] = useState<string | null>(null);
   const [heatmapLevel, setHeatmapLevel] = useState<number>(2); // 0-4, default 2 (512px)
   const [heatmapAlphaPower, setHeatmapAlphaPower] = useState<number>(0.7); // 0.1-1.5, controls low-attention visibility
+  const [heatmapSmooth, setHeatmapSmooth] = useState<boolean>(false); // optional interpolated view (visual only)
   // Debounce alpha power so heatmap only re-fetches after user stops sliding
   const [debouncedAlphaPower, setDebouncedAlphaPower] = useState<number>(0.7);
   useEffect(() => {
@@ -1779,7 +1780,14 @@ function HomePage() {
     heatmapModel ?? scopedProjectModels[0]?.id ?? currentProject?.prediction_target ?? null;
 
   const heatmapData = selectedSlide && effectiveHeatmapModel ? {
-    imageUrl: getHeatmapUrl(selectedSlide.id, effectiveHeatmapModel, heatmapLevel, debouncedAlphaPower, currentProject?.id),
+    imageUrl: getHeatmapUrl(
+      selectedSlide.id,
+      effectiveHeatmapModel,
+      heatmapLevel,
+      debouncedAlphaPower,
+      currentProject?.id,
+      heatmapSmooth,
+    ),
     minValue: 0,
     maxValue: 1,
     colorScale: "viridis" as const,
@@ -2184,6 +2192,8 @@ function HomePage() {
                 onHeatmapLevelChange={setHeatmapLevel}
                 heatmapAlphaPower={heatmapAlphaPower}
                 onHeatmapAlphaPowerChange={setHeatmapAlphaPower}
+                heatmapSmooth={heatmapSmooth}
+                onHeatmapSmoothChange={setHeatmapSmooth}
                 onHeatmapModelChange={setHeatmapModel}
                 availableModels={scopedProjectModels.map((m) => ({ id: m.id, name: m.name }))}
                 onControlsReady={(controls) => { viewerControlsRef.current = controls; }}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -710,13 +710,21 @@ export function getDziUrl(slideId: string, projectId?: string): string {
  * 
  * Uses local Next.js API proxy to avoid CORS issues.
  */
-export function getHeatmapUrl(slideId: string, modelId?: string, level?: number, alphaPower?: number, projectId?: string): string {
+export function getHeatmapUrl(
+  slideId: string,
+  modelId?: string,
+  level?: number,
+  alphaPower?: number,
+  projectId?: string,
+  smooth?: boolean,
+): string {
   const params = new URLSearchParams();
   if (level !== undefined) params.set('level', String(level));
   if (alphaPower !== undefined && Math.abs(alphaPower - 0.7) > 0.01) {
     params.set('alpha_power', alphaPower.toFixed(2));
   }
   if (projectId) params.set('project_id', projectId);
+  if (smooth) params.set('smooth', 'true');
   const qs = params.toString() ? `?${params.toString()}` : '';
   if (modelId) {
     return `/api/heatmap/${encodeURIComponent(slideId)}/${encodeURIComponent(modelId)}${qs}`;

--- a/src/enso_atlas/api/main.py
+++ b/src/enso_atlas/api/main.py
@@ -6070,6 +6070,10 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
         slide_id: str,
         model_id: str,
         alpha_power: float = 0.7,
+        smooth: bool = Query(
+            default=False,
+            description="Apply Gaussian blur interpolation for denser visualization (False keeps truthful patch-grid rendering)",
+        ),
         project_id: Optional[str] = Query(default=None, description="Project ID to scope embeddings lookup")
     ):
         """Get the attention heatmap for a specific TransMIL model.
@@ -6151,8 +6155,9 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
         cache_dir = _model_heatmap_embeddings_dir / "heatmap_cache"
         cache_dir.mkdir(exist_ok=True)
         is_default_alpha = abs(alpha_power - 0.7) < 0.01
+        mode_suffix = "smooth" if smooth else "truthful"
         cache_suffix = project_id if project_id else "global"
-        cache_path = cache_dir / f"{cache_suffix}_{slide_id}_{model_id}_v2.png"
+        cache_path = cache_dir / f"{cache_suffix}_{slide_id}_{model_id}_{mode_suffix}_v3.png"
 
         if is_default_alpha and cache_path.exists():
             # Serve cached heatmap — still need slide dims for headers
@@ -6252,8 +6257,8 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
                 coords_list,
                 slide_dims,
                 thumbnail_size=(grid_w, grid_h),
-                smooth=False,
-                blur_kernel=1,
+                smooth=smooth,
+                blur_kernel=31 if smooth else 1,
                 alpha_power=alpha_power,
             )
             


### PR DESCRIPTION
## Summary
- add an explicit UI note that heatmap density reflects extracted patch coverage
- add an optional "Interpolated view" toggle in the viewer (visual smoothing only)
- plumb a `smooth` query param through frontend heatmap URL + proxy routes
- add backend support for `smooth` on model-specific heatmap endpoint while keeping truthful patch-grid rendering as default

## Testing
- `npm run check:heatmap-alignment`
- `npm run check:model-scope`
- `python3 -m py_compile src/enso_atlas/api/main.py src/enso_atlas/evidence/generator.py`

## Notes
- `python3 -m pytest ...` could not run in this environment because `pytest` is not installed.
- `npm run lint` could not run in this environment because `next` is unavailable (frontend dependencies not installed in PATH).