### PR TITLE
fix: gate multi-model panel actions for single-model projects

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1115,6 +1115,13 @@ function HomePage() {
   const handleMultiModelAnalyze = useCallback(async (forceRefresh: boolean = false) => {
     if (!selectedSlide) return;
 
+    // Safety gate: single-model projects should never execute multi-model inference.
+    if (scopedProjectModels.length <= 1) {
+      setMultiModelResult(null);
+      setMultiModelError(null);
+      return;
+    }
+
     // Clear previous results and cache state
     setMultiModelResult(null);
     setIsCachedResult(false);
@@ -1893,7 +1900,7 @@ function HomePage() {
           qcMetrics={slideQCMetrics}
           isCached={isCachedResult && !analysisResult}
           cachedAt={cachedResultTimestamp}
-          onReanalyze={selectedSlide ? handleReanalyze : undefined}
+          onReanalyze={selectedSlide ? handleAnalyze : undefined}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- prevent multi-model inference from running in single-model projects by adding a guard in `handleMultiModelAnalyze`
- route cached prediction panel "Re-analyze" to the standard analysis flow so single-model projects re-run safely without invoking multi-model endpoints
- keep existing evidence significance gating behavior (`attentionWeight` threshold + minimum patch count) intact

## Testing
- `npm run lint` (passes; existing warnings only)
- `npm run build` (passes)
- `npm run check:model-scope` (passes)

## Issue
Fixes #52