### PR TITLE
fix: surface coords-missing heatmap errors and prevent synthetic PDF fallback

### DIFF
--- a/frontend/src/app/api/heatmap/[slideId]/[modelId]/route.ts
+++ b/frontend/src/app/api/heatmap/[slideId]/[modelId]/route.ts
@@ -28,9 +28,16 @@ export async function GET(
     });
 
     if (!response.ok) {
-      return NextResponse.json(
-        { error: `Backend returned ${response.status}` },
-        { status: response.status }
+      const errorBody = await response.text();
+      return new NextResponse(
+        errorBody || JSON.stringify({ error: `Backend returned ${response.status}` }),
+        {
+          status: response.status,
+          headers: {
+            "Content-Type": response.headers.get("Content-Type") || "application/json",
+            "Cache-Control": "no-store",
+          },
+        }
       );
     }
 

--- a/frontend/src/app/api/heatmap/[slideId]/route.ts
+++ b/frontend/src/app/api/heatmap/[slideId]/route.ts
@@ -29,9 +29,16 @@ export async function GET(
     });
 
     if (!response.ok) {
-      return NextResponse.json(
-        { error: `Backend returned ${response.status}` },
-        { status: response.status }
+      const errorBody = await response.text();
+      return new NextResponse(
+        errorBody || JSON.stringify({ error: `Backend returned ${response.status}` }),
+        {
+          status: response.status,
+          headers: {
+            "Content-Type": response.headers.get("Content-Type") || "application/json",
+            "Cache-Control": "no-store",
+          },
+        }
       );
     }
 

--- a/src/enso_atlas/api/main.py
+++ b/src/enso_atlas/api/main.py
@@ -3551,18 +3551,14 @@ DISCLAIMER: This is a research tool. All findings must be validated by qualified
                 if emb_path.exists() and classifier is not None and evidence_gen is not None:
                     embeddings = np.load(emb_path)
                     
-                    # Load coordinates
+                    # Load coordinates (required for truthful localization)
                     patch_size = 224
                     if coord_path.exists():
                         coords_arr = np.load(coord_path).astype(np.int64, copy=False)
                     else:
-                        n_patches = len(embeddings)
-                        grid_size = int(np.ceil(np.sqrt(n_patches)))
-                        grid_x, grid_y = np.meshgrid(
-                            np.arange(grid_size) * patch_size,
-                            np.arange(grid_size) * patch_size,
+                        raise FileNotFoundError(
+                            f"Patch coordinates missing for {slide_id}; cannot generate truthful PDF heatmap."
                         )
-                        coords_arr = np.stack([grid_x.ravel(), grid_y.ravel()], axis=1)[:n_patches]
                     
                     coords = [tuple(map(int, c)) for c in coords_arr]
                     

--- a/tests/test_frontend_heatmap_error_message.py
+++ b/tests/test_frontend_heatmap_error_message.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_wsi_viewer_extracts_backend_heatmap_error_messages():
+    src = _read("frontend/src/components/viewer/WSIViewer.tsx")
+
+    assert "extractHeatmapErrorMessage" in src
+    assert "setHeatmapErrorMessage(extractHeatmapErrorMessage(response.status, errorBody))" in src
+    assert "Patch coordinates are missing for this slide." in src
+
+
+def test_wsi_viewer_renders_heatmap_error_message_in_toolbar():
+    src = _read("frontend/src/components/viewer/WSIViewer.tsx")
+
+    assert "{heatmapError && heatmapErrorMessage && (" in src
+    assert "text-2xs text-red-600" in src

--- a/tests/test_frontend_heatmap_proxy_scoping.py
+++ b/tests/test_frontend_heatmap_proxy_scoping.py
@@ -32,3 +32,19 @@ def test_api_client_uses_project_scoped_models_endpoint_and_heatmap_query_param(
     assert "getProjectAvailableModels" in src
     assert "getHeatmapUrl" in src
     assert "params.set('project_id', projectId)" in src or 'params.set("project_id", projectId)' in src
+
+
+def test_model_heatmap_proxy_preserves_backend_error_payload_for_ui_messages():
+    src = _read("frontend/src/app/api/heatmap/[slideId]/[modelId]/route.ts")
+
+    assert "const errorBody = await response.text();" in src
+    assert "return new NextResponse(" in src
+    assert '"Content-Type": response.headers.get("Content-Type") || "application/json"' in src
+
+
+def test_slide_heatmap_proxy_preserves_backend_error_payload_for_ui_messages():
+    src = _read("frontend/src/app/api/heatmap/[slideId]/route.ts")
+
+    assert "const errorBody = await response.text();" in src
+    assert "return new NextResponse(" in src
+    assert '"Content-Type": response.headers.get("Content-Type") || "application/json"' in src

--- a/tests/test_heatmap_grid_alignment.py
+++ b/tests/test_heatmap_grid_alignment.py
@@ -55,8 +55,9 @@ def test_osd_overlay_width_scales_to_grid_coverage_ratio():
 def test_frontend_alignment_formula_present_in_viewer_regression_contract():
     src = _read("frontend/src/components/viewer/WSIViewer.tsx")
 
-    assert "const coverageW = Math.ceil(contentSize.x / PATCH_SIZE) * PATCH_SIZE;" in src
-    assert "const heatmapWidth = bounds.width * (coverageW / contentSize.x);" in src
+    assert "const fallbackCoverageW = Math.ceil(contentSize.x / DEFAULT_PATCH_SIZE_PX) * DEFAULT_PATCH_SIZE_PX;" in src
+    assert "const widthScale = bounds.width / contentSize.x;" in src
+    assert "const heatmapWorldWidth = coverageW * widthScale;" in src
 
 
 def test_backend_model_heatmap_sets_coverage_headers_from_shared_helper():
@@ -65,3 +66,9 @@ def test_backend_model_heatmap_sets_coverage_headers_from_shared_helper():
     assert "from .heatmap_grid import compute_heatmap_grid_coverage" in src
     assert '"X-Coverage-Width": str(_coverage.coverage_width)' in src
     assert '"X-Coverage-Height": str(_coverage.coverage_height)' in src
+
+
+def test_pdf_heatmap_path_does_not_fabricate_synthetic_coords_when_missing():
+    src = _read("src/enso_atlas/api/main.py")
+
+    assert "cannot generate truthful PDF heatmap" in src


### PR DESCRIPTION
## Summary
- preserve backend heatmap error payloads in frontend API proxies so `COORDS_REQUIRED_FOR_HEATMAP` details are not lost
- surface backend heatmap error messages in `WSIViewer` (including explicit guidance when coords are missing)
- prevent synthetic coordinate fabrication in PDF heatmap generation by requiring real `*_coords.npy`
- add/refresh regression checks for proxy error pass-through, viewer error messaging, and heatmap alignment contract

## Testing
- `python -m pytest -q tests/test_frontend_heatmap_proxy_scoping.py tests/test_frontend_heatmap_error_message.py tests/test_heatmap_grid_alignment.py`
- `node scripts/check-heatmap-grid-alignment.mjs` (run from `frontend/`)

Fixes Hilo-Hilo/med-gemma-hackathon#51