### PR TITLE
fix: remove remaining treatment-response copy leakage in project-agnostic panels

### DIFF
--- a/frontend/src/components/modals/PatchZoomModal.tsx
+++ b/frontend/src/components/modals/PatchZoomModal.tsx
@@ -39,6 +39,8 @@ export function PatchZoomModal({
   const [zoomLevel, setZoomLevel] = React.useState(1);
   const { currentProject } = useProject();
   const predictionTargetLabel = humanizeIdentifier(currentProject.prediction_target).toLowerCase();
+  const positiveLabel = (currentProject.positive_class || currentProject.classes?.[1] || "positive").toLowerCase();
+  const negativeLabel = (currentProject.classes?.find((c) => c !== currentProject.positive_class) || currentProject.classes?.[0] || "negative").toLowerCase();
 
   // Sort patches by attention weight for rank
   const sortedPatches = [...allPatches].sort(
@@ -116,7 +118,7 @@ export function PatchZoomModal({
 
     const weight = patch.attentionWeight;
     if (weight >= 0.7) {
-      return `High attention region showing distinctive cellular patterns that strongly influence the model's prediction. This area contains morphological features characteristic of the predicted ${predictionTargetLabel} class.`;
+      return `High attention region showing distinctive cellular patterns that strongly influence the model's prediction. This area contains morphology relevant to ${predictionTargetLabel} assessment (e.g., ${negativeLabel} vs ${positiveLabel}).`;
     } else if (weight >= 0.4) {
       return "Moderate attention region with notable tissue architecture. The cellular composition and spatial arrangement in this patch contribute to the overall prediction confidence.";
     } else {

--- a/frontend/src/components/panels/PredictionPanel.tsx
+++ b/frontend/src/components/panels/PredictionPanel.tsx
@@ -169,8 +169,8 @@ export function PredictionPanel({
     );
   }
 
-  // Determine responder status
-  const isResponder = prediction.score >= 0.5;
+  // Determine predicted class side (threshold-based binary decision)
+  const isPositivePrediction = prediction.score >= 0.5;
   const probabilityPercent = Math.round(prediction.score * 100);
 
   // Risk stratification
@@ -248,14 +248,14 @@ export function PredictionPanel({
         <div
           className={cn(
             "p-4 rounded-xl border-2 transition-all",
-            isResponder
+            isPositivePrediction
               ? "bg-responder-positive-bg border-responder-positive-border"
               : "bg-responder-negative-bg border-responder-negative-border"
           )}
         >
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
-              {isResponder ? (
+              {isPositivePrediction ? (
                 <CheckCircle className="h-6 w-6 text-responder-positive" />
               ) : (
                 <XCircle className="h-6 w-6 text-responder-negative" />
@@ -263,12 +263,12 @@ export function PredictionPanel({
               <span
                 className={cn(
                   "text-xl font-bold tracking-tight",
-                  isResponder
+                  isPositivePrediction
                     ? "text-responder-positive"
                     : "text-responder-negative"
                 )}
               >
-                {isResponder ? positiveLabel.toUpperCase() : negativeLabel.toUpperCase()}
+                {isPositivePrediction ? positiveLabel.toUpperCase() : negativeLabel.toUpperCase()}
               </span>
             </div>
             <Badge
@@ -299,7 +299,7 @@ export function PredictionPanel({
                 <span>Uncalibrated - do not interpret as true probability</span>
               </div>
               <p className="text-xs text-gray-600 leading-relaxed">
-                {isResponder
+                {isPositivePrediction
                   ? `Model predicts ${positiveLabel.toLowerCase()} for ${predictionTargetLabel.toLowerCase()} based on histopathological features.`
                   : `Model predicts ${negativeLabel.toLowerCase()} for ${predictionTargetLabel.toLowerCase()}. Correlate with clinical context before action.`}
               </p>
@@ -318,7 +318,7 @@ export function PredictionPanel({
 
           {/* Visual Probability Bar */}
           <div className="probability-bar">
-            {/* Non-responder zone (red) */}
+            {/* Lower-score zone (red) */}
             <div
               className="absolute left-0 top-0 h-full bg-gradient-to-r from-red-100 to-red-200"
               style={{ width: "50%" }}
@@ -332,7 +332,7 @@ export function PredictionPanel({
             <div
               className={cn(
                 "absolute top-0 h-full w-1.5 rounded-full shadow-md transition-all duration-700 ease-out",
-                isResponder ? "bg-status-positive" : "bg-status-negative"
+                isPositivePrediction ? "bg-status-positive" : "bg-status-negative"
               )}
               style={{ left: `calc(${probabilityPercent}% - 3px)` }}
             />


### PR DESCRIPTION
## Summary
- make PredictionPanel internal state wording project-agnostic (rename responder-specific state/comment usage in prediction copy logic)
- update PatchZoomModal fallback morphology copy to reference project target and class labels instead of implicit treatment-response semantics
- update AIAssistant suggested/quick prompts to be project-target aware and remove hardcoded prognosis/treatment-response phrasing in generic views

## Testing
- `npm run lint` (passes with existing warnings only)
- `npm run build`
- `npm run check:model-scope`

Fixes Hilo-Hilo/med-gemma-hackathon#47