### PR TITLE
fix: stop project patient-context label lookups from using global fallback

### DIFF
--- a/scripts/validate_project_scoping.py
+++ b/scripts/validate_project_scoping.py
@@ -56,6 +56,16 @@ def main() -> None:
         "_report_embeddings_dir = _resolve_project_embeddings_dir(",
         "Report generation resolves project-scoped embeddings dir",
     )
+    require(
+        src,
+        "if proj_cfg:\n            labels_path = _project_labels_path(project_id)\n        else:\n            labels_path = _data_root / \"labels.csv\"",
+        "Flat-file listing uses project labels path only when project_id is provided",
+    )
+    require(
+        src,
+        "if project_id:\n            if labels_path is None:\n                return None\n        else:\n            if labels_path is None:\n                labels_path = _data_root / \"labels.csv\"",
+        "Patient context global-label fallback only applies to non-project requests",
+    )
 
     print("\nAll project-scoping validation checks passed.")
 

--- a/src/enso_atlas/api/main.py
+++ b/src/enso_atlas/api/main.py
@@ -2608,13 +2608,22 @@ def create_app(
         slide_id: str,
         project_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Load patient context from a project's labels file for a slide."""
+        """Load patient context from labels for a slide.
+
+        Project-scoped requests must only read the configured project labels file.
+        Global fallback labels are allowed only for non-project requests.
+        """
         _require_project(project_id)
         labels_path = _project_labels_path(project_id)
-        if labels_path is None:
-            labels_path = _data_root / "labels.csv"
-            if not labels_path.exists():
-                labels_path = embeddings_dir.parent / "labels.csv"
+
+        if project_id:
+            if labels_path is None:
+                return None
+        else:
+            if labels_path is None:
+                labels_path = _data_root / "labels.csv"
+                if not labels_path.exists():
+                    labels_path = embeddings_dir.parent / "labels.csv"
 
         if not labels_path.exists() or labels_path.suffix.lower() != ".csv":
             return None

--- a/tests/test_backend_project_scoping_regressions.py
+++ b/tests/test_backend_project_scoping_regressions.py
@@ -36,3 +36,14 @@ def test_report_paths_resolve_project_specific_embeddings_before_processing():
     src = _main_source()
     assert "report_embeddings_dir = _resolve_project_embeddings_dir(" in src
     assert "_report_embeddings_dir = _resolve_project_embeddings_dir(" in src
+
+
+def test_flat_file_listing_uses_project_labels_without_global_fallback():
+    src = _main_source()
+    assert "if proj_cfg:\n            labels_path = _project_labels_path(project_id)\n        else:\n            labels_path = _data_root / \"labels.csv\"" in src
+
+
+def test_patient_context_global_label_fallback_is_non_project_only():
+    src = _main_source()
+    assert "labels_path = _project_labels_path(project_id)" in src
+    assert "if project_id:\n            if labels_path is None:\n                return None\n        else:\n            if labels_path is None:\n                labels_path = _data_root / \"labels.csv\"" in src


### PR DESCRIPTION
## Summary
- keep `_load_patient_context` strictly project-scoped when `project_id` is provided
- only allow legacy global labels fallback for non-project requests
- extend project scoping regression checks to cover labels-path behavior

## Testing
- `python3 scripts/validate_project_scoping.py`
- `python3 -m compileall -q src/enso_atlas/api/main.py`

## Notes
- `pytest` is not available in this runtime (`No module named pytest`), so source-based regression checks were used for this scoped fix.

Fixes #45