### PR TITLE
fix: unify project model scope resolution across models and multi-analysis

### DIFF
--- a/src/enso_atlas/api/main.py
+++ b/src/enso_atlas/api/main.py
@@ -757,22 +757,25 @@ def create_app(
         return slide_ids
 
     async def _resolve_project_model_ids(project_id: Optional[str]) -> Optional[set[str]]:
-        """Resolve allowed model ids for a project (DB first, YAML fallback)."""
+        """Resolve allowed model ids for a project via shared model-scope helper.
+
+        Resolution order is centralized in model_scope.resolve_project_model_scope:
+        1) DB project_models assignments
+        2) YAML classification_models fallback
+        """
         if not project_id:
             return None
 
-        proj_cfg = _require_project(project_id)
-        allowed: set[str] = set()
+        scope = await resolve_project_model_scope(
+            project_id,
+            project_registry=project_registry,
+            get_project_models=db.get_project_models,
+            logger=logger,
+        )
+        if not scope.project_exists:
+            raise HTTPException(status_code=404, detail=f"Unknown project_id: {project_id}")
 
-        try:
-            allowed.update(await db.get_project_models(project_id))
-        except Exception as e:
-            logger.warning(f"DB model query failed for {project_id}: {e}")
-
-        if not allowed and proj_cfg and proj_cfg.classification_models:
-            allowed.update(proj_cfg.classification_models)
-
-        return allowed
+        return scope.allowed_model_ids
 
 
     @app.on_event("startup")

--- a/tests/test_backend_project_scoping_regressions.py
+++ b/tests/test_backend_project_scoping_regressions.py
@@ -10,6 +10,7 @@ def test_models_and_multi_analysis_share_project_model_resolution():
     src = _main_source()
     assert "allowed_ids = await _resolve_project_model_ids(project_id)" in src
     assert "allowed_model_ids = await _resolve_project_model_ids(request.project_id)" in src
+    assert "scope = await resolve_project_model_scope(" in src
 
 
 def test_async_batch_propagates_project_id_to_background_worker():

--- a/tests/test_model_scope.py
+++ b/tests/test_model_scope.py
@@ -88,6 +88,24 @@ def test_resolve_project_model_scope_unknown_project():
     assert scope.allowed_model_ids == set()
 
 
+def test_resolve_project_model_scope_treats_db_assignments_as_existing_project():
+    registry = _FakeRegistry({})
+
+    async def get_project_models(project_id: str):
+        return await _db_models_factory({"db-only-project": ["tumor_grade"]}, project_id)
+
+    scope = asyncio.run(
+        resolve_project_model_scope(
+            "db-only-project",
+            project_registry=registry,
+            get_project_models=get_project_models,
+        )
+    )
+
+    assert scope.project_exists is True
+    assert scope.allowed_model_ids == {"tumor_grade"}
+
+
 def test_filter_models_for_scope_filters_by_id_and_model_id_fields():
     models = [
         {"id": "lung_stage", "name": "Lung Stage"},


### PR DESCRIPTION
## Summary
- route project model ID resolution through shared `resolve_project_model_scope` helper (DB assignments first, YAML fallback)
- keep `/api/models` and `/api/analyze-multi` using the same resolver path via `_resolve_project_model_ids`
- preserve explicit model allowlist enforcement for project-scoped analysis requests

## Testing
- `python -m pytest -q tests/test_model_scope.py tests/test_backend_project_scoping_regressions.py`
- `python -m compileall -q src/enso_atlas/api/main.py src/enso_atlas/api/model_scope.py tests/test_model_scope.py tests/test_backend_project_scoping_regressions.py`

Fixes Hilo-Hilo/med-gemma-hackathon#42