### PR TITLE
fix: enforce project-scoped dataset paths in setup scripts and project creation

### DIFF
--- a/scripts/setup_luad_project.py
+++ b/scripts/setup_luad_project.py
@@ -58,6 +58,17 @@ def _resolve_repo_relative(path_str: str) -> Path:
     return p if p.is_absolute() else (REPO_ROOT / p)
 
 
+def _project_root_from_dataset_path(project_id: str, path_str: str) -> Path | None:
+    """Return absolute data/projects/<project_id> root for a dataset path, if present."""
+    abs_path = _resolve_repo_relative(path_str).resolve()
+    marker = ("data", "projects", project_id)
+    parts = abs_path.parts
+    for idx in range(len(parts) - 2):
+        if parts[idx: idx + 3] == marker:
+            return Path(*parts[: idx + 3])
+    return None
+
+
 def resolve_output_dir(
     project_id: str,
     projects_config: Path,
@@ -73,12 +84,27 @@ def resolve_output_dir(
         proj = (raw.get("projects") or {}).get(project_id)
         if proj:
             dataset = proj.get("dataset") or {}
-            labels_file = dataset.get("labels_file")
-            if labels_file:
-                return _resolve_repo_relative(labels_file).parent
-            slides_dir = dataset.get("slides_dir")
-            if slides_dir:
-                return _resolve_repo_relative(slides_dir).parent
+            roots = set()
+            for field in ("slides_dir", "embeddings_dir", "labels_file"):
+                path_val = dataset.get(field)
+                if not path_val:
+                    continue
+                root = _project_root_from_dataset_path(project_id, path_val)
+                if root is None:
+                    raise ValueError(
+                        f"Project '{project_id}' has non-modular dataset.{field} path in "
+                        f"{projects_config}: {path_val}"
+                    )
+                roots.add(root)
+
+            if len(roots) > 1:
+                sorted_roots = ", ".join(str(p) for p in sorted(roots))
+                raise ValueError(
+                    f"Project '{project_id}' has inconsistent dataset roots in {projects_config}: "
+                    f"{sorted_roots}"
+                )
+            if roots:
+                return roots.pop()
 
     # Fallback for projects not yet in config
     return REPO_ROOT / "data" / "projects" / project_id

--- a/src/enso_atlas/api/project_routes.py
+++ b/src/enso_atlas/api/project_routes.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException, UploadFile, File
 from pydantic import BaseModel, Field
 
-from .projects import ProjectConfig, ProjectRegistry
+from .projects import ProjectConfig, ProjectRegistry, default_dataset_paths
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +132,7 @@ async def create_project(body: CreateProjectRequest):
     reg = get_registry()
 
     # Build config dict from the request body
+    dataset_paths = default_dataset_paths(body.id)
     config = {
         "name": body.name,
         "cancer_type": body.cancer_type,
@@ -140,9 +141,7 @@ async def create_project(body: CreateProjectRequest):
         "positive_class": body.positive_class,
         "description": body.description,
         "dataset": {
-            "slides_dir": f"data/projects/{body.id}/slides",
-            "embeddings_dir": f"data/projects/{body.id}/embeddings",
-            "labels_file": f"data/projects/{body.id}/labels.csv",
+            **dataset_paths,
             "label_column": body.prediction_target,
         },
     }

--- a/tests/test_setup_project_scripts.py
+++ b/tests/test_setup_project_scripts.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script_module(rel_path: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SCRIPTS = (
+    _load_script_module("scripts/setup_luad_project.py", "setup_luad_project"),
+    _load_script_module("scripts/setup_brca_project.py", "setup_brca_project"),
+)
+
+
+def _write_projects_config(tmpdir: str, config_text: str) -> Path:
+    config_path = Path(tmpdir) / "projects.yaml"
+    config_path.write_text(config_text, encoding="utf-8")
+    return config_path
+
+
+def test_resolve_output_dir_uses_project_root_from_config():
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _write_projects_config(
+            td,
+            """
+projects:
+  demo-proj:
+    dataset:
+      slides_dir: data/projects/demo-proj/slides
+      embeddings_dir: data/projects/demo-proj/embeddings/level0
+      labels_file: data/projects/demo-proj/labels.json
+""".strip(),
+        )
+
+        expected = (REPO_ROOT / "data" / "projects" / "demo-proj").resolve()
+        for module in SCRIPTS:
+            resolved = module.resolve_output_dir("demo-proj", cfg, None)
+            assert resolved.resolve() == expected
+
+
+def test_resolve_output_dir_rejects_non_modular_config_paths():
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _write_projects_config(
+            td,
+            """
+projects:
+  demo-proj:
+    dataset:
+      slides_dir: data/slides
+      embeddings_dir: data/embeddings
+      labels_file: data/labels.csv
+""".strip(),
+        )
+
+        for module in SCRIPTS:
+            try:
+                module.resolve_output_dir("demo-proj", cfg, None)
+                assert False, "Expected ValueError for non-modular dataset paths"
+            except ValueError as exc:
+                assert "non-modular" in str(exc)
+
+
+def test_resolve_output_dir_rejects_inconsistent_dataset_roots():
+    with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as external:
+        external_labels = Path(external) / "data" / "projects" / "demo-proj" / "labels.csv"
+        cfg = _write_projects_config(
+            td,
+            f"""
+projects:
+  demo-proj:
+    dataset:
+      slides_dir: data/projects/demo-proj/slides
+      embeddings_dir: data/projects/demo-proj/embeddings
+      labels_file: {external_labels}
+""".strip(),
+        )
+
+        for module in SCRIPTS:
+            try:
+                module.resolve_output_dir("demo-proj", cfg, None)
+                assert False, "Expected ValueError for inconsistent dataset roots"
+            except ValueError as exc:
+                assert "inconsistent dataset roots" in str(exc)


### PR DESCRIPTION
## Summary
- use `default_dataset_paths()` in `POST /api/projects` so created projects always inherit the canonical `data/projects/<project_id>/...` layout
- tighten `setup_luad_project.py` and `setup_brca_project.py` output resolution to validate configured dataset paths are modular and rooted consistently for the target project
- add tests for setup script path resolution and validation behavior

## Testing
- `python3 scripts/validate_project_modularity.py`
- `python3 -m py_compile src/enso_atlas/api/project_routes.py scripts/setup_luad_project.py scripts/setup_brca_project.py tests/test_setup_project_scripts.py`
- custom inline Python checks for `resolve_output_dir()` in both setup scripts (consistent config, non-modular config, inconsistent roots)

Fixes Hilo-Hilo/med-gemma-hackathon#44