### PR TITLE
fix: propagate async project-scoped labels and threshold handling

### DIFF
--- a/src/enso_atlas/api/main.py
+++ b/src/enso_atlas/api/main.py
@@ -1975,8 +1975,19 @@ def create_app(
                     },
                 )
 
+        task_pos_label, task_neg_label = _resolve_project_label_pair(
+            request.project_id,
+            positive_default="RESPONDER",
+            negative_default="NON-RESPONDER",
+            uppercase=True,
+        )
+
         # Create task
-        task = batch_task_manager.create_task(request.slide_ids)
+        task = batch_task_manager.create_task(
+            request.slide_ids,
+            positive_label=task_pos_label,
+            negative_label=task_neg_label,
+        )
 
         # Run batch analysis in background
         def run_batch_analysis():
@@ -3147,7 +3158,10 @@ should incorporate all available clinical, pathological, and molecular data."""
             )
             
             score, attention = classifier.predict(embeddings)
-            threshold_val = getattr(classifier.config, "threshold", 0.5)
+            threshold_val = getattr(classifier, "threshold", None)
+            if threshold_val is None:
+                threshold_val = 0.5
+            threshold_val = float(threshold_val)
             label = positive_label if score >= threshold_val else negative_label
             
             report_task_manager.update_task(task_id,
@@ -3342,8 +3356,13 @@ should incorporate all available clinical, pathological, and molecular data."""
                     similar_cases, patient_ctx, decision_support_data, cancer_type
                 )
                 summary_text = _create_template_summary(
-                    slide_id, label, float(score), len(embeddings),
-                    patient_ctx, similar_cases
+                    slide_id,
+                    label,
+                    float(score),
+                    len(embeddings),
+                    patient_ctx,
+                    similar_cases,
+                    decision_threshold=threshold_val,
                 )
             
             report_task_manager.update_task(task_id,
@@ -3421,9 +3440,17 @@ should incorporate all available clinical, pathological, and molecular data."""
             "decision_support": decision_support_data,
         }
     
-    def _create_template_summary(slide_id, label, score, num_patches, patient_ctx, similar_cases):
+    def _create_template_summary(
+        slide_id,
+        label,
+        score,
+        num_patches,
+        patient_ctx,
+        similar_cases,
+        decision_threshold: float = 0.5,
+    ):
         """Create a fallback template summary."""
-        confidence = abs(score - 0.5) * 2
+        confidence = abs(score - decision_threshold) * 2
         return f"""CASE ANALYSIS SUMMARY
 Case ID: {slide_id}
 Prediction: {label.upper()}

--- a/tests/test_backend_project_scoping_regressions.py
+++ b/tests/test_backend_project_scoping_regressions.py
@@ -6,6 +6,11 @@ def _main_source() -> str:
     return main_py.read_text()
 
 
+def _batch_tasks_source() -> str:
+    path = Path(__file__).resolve().parents[1] / "src" / "enso_atlas" / "api" / "batch_tasks.py"
+    return path.read_text()
+
+
 def test_models_and_multi_analysis_share_project_model_resolution():
     src = _main_source()
     assert "allowed_ids = await _resolve_project_model_ids(project_id)" in src
@@ -36,3 +41,17 @@ def test_report_paths_resolve_project_specific_embeddings_before_processing():
     src = _main_source()
     assert "report_embeddings_dir = _resolve_project_embeddings_dir(" in src
     assert "_report_embeddings_dir = _resolve_project_embeddings_dir(" in src
+
+
+def test_async_report_uses_classifier_threshold_consistently_with_sync_path():
+    src = _main_source()
+    assert "threshold_val = getattr(classifier, \"threshold\", None)" in src
+    assert "getattr(classifier.config, \"threshold\", 0.5)" not in src
+
+
+def test_async_batch_task_summary_uses_task_label_pair_not_hardcoded_response_labels():
+    src = _batch_tasks_source()
+    assert 'responders = [r for r in completed if r.prediction == self.positive_label]' in src
+    assert 'non_responders = [r for r in completed if r.prediction == self.negative_label]' in src
+    assert 'r.prediction == "RESPONDER"' not in src
+    assert 'r.prediction == "NON-RESPONDER"' not in src


### PR DESCRIPTION
## Summary
- pass project label pair into async batch task metadata so status/summary counts are derived from project-configured classes (instead of hardcoded RESPONDER/NON-RESPONDER)
- keep async report fallback prediction threshold logic consistent with sync path by using `classifier.threshold`
- use the same resolved threshold for async template-summary confidence

## Testing
- `python3 - <<'PY' ... py_compile + regression-assert execution ... PY` (compiled changed files and executed all assertions in `tests/test_backend_project_scoping_regressions.py`)
- `python3 - <<'PY' ... BatchTask custom-label smoke ... PY` (validated async batch summary counts with custom label pair)

## Notes
- changes are scoped to async batch/report paths and regression tests only
- no unrelated refactors
