### PR TITLE
fix: enforce project-scoped async report preflight task resolution

### DIFF
--- a/src/enso_atlas/api/main.py
+++ b/src/enso_atlas/api/main.py
@@ -3062,8 +3062,8 @@ should incorporate all available clinical, pathological, and molecular data."""
         if not emb_path.exists():
             raise HTTPException(status_code=404, detail=f"Slide {slide_id} not found")
         
-        # Check for existing task
-        existing_task = report_task_manager.get_task_by_slide(slide_id)
+        # Check for existing task in the same project scope
+        existing_task = report_task_manager.get_task_by_slide(slide_id, request.project_id)
         if existing_task:
             return AsyncReportResponse(
                 task_id=existing_task.task_id,
@@ -3074,7 +3074,7 @@ should incorporate all available clinical, pathological, and molecular data."""
             )
         
         # Create new task
-        task = report_task_manager.create_task(slide_id)
+        task = report_task_manager.create_task(slide_id, request.project_id)
         
         # Run report generation in background
         def run_report_generation():

--- a/tests/test_backend_project_scoping_regressions.py
+++ b/tests/test_backend_project_scoping_regressions.py
@@ -6,6 +6,11 @@ def _main_source() -> str:
     return main_py.read_text()
 
 
+def _report_tasks_source() -> str:
+    report_tasks_py = Path(__file__).resolve().parents[1] / "src" / "enso_atlas" / "api" / "report_tasks.py"
+    return report_tasks_py.read_text()
+
+
 def test_models_and_multi_analysis_share_project_model_resolution():
     src = _main_source()
     assert "allowed_ids = await _resolve_project_model_ids(project_id)" in src
@@ -36,3 +41,15 @@ def test_report_paths_resolve_project_specific_embeddings_before_processing():
     src = _main_source()
     assert "report_embeddings_dir = _resolve_project_embeddings_dir(" in src
     assert "_report_embeddings_dir = _resolve_project_embeddings_dir(" in src
+
+
+def test_async_report_preflight_is_project_scoped():
+    main_src = _main_source()
+    task_src = _report_tasks_source()
+
+    assert "existing_task = report_task_manager.get_task_by_slide(slide_id, request.project_id)" in main_src
+    assert "task = report_task_manager.create_task(slide_id, request.project_id)" in main_src
+
+    assert "project_id: Optional[str] = None" in task_src
+    assert "def get_task_by_slide(self, slide_id: str, project_id: Optional[str] = None)" in task_src
+    assert "task.project_id == project_id" in task_src


### PR DESCRIPTION
## Summary
- make async report preflight task lookup project-scoped by matching both `slide_id` and `project_id`
- persist `project_id` on `ReportTask` so overlapping slide IDs across projects do not reuse the wrong in-flight task
- pass `project_id` through report task creation from `/api/report/async`
- add regression coverage for project-scoped async report preflight

## Testing
- `source .venv/bin/activate && pytest -q tests/test_backend_project_scoping_regressions.py`
- `python3 -m compileall src/enso_atlas/api/main.py src/enso_atlas/api/report_tasks.py tests/test_backend_project_scoping_regressions.py`

## Notes
- existing task deduplication remains intact for repeated requests within the same project scope
- no behavior change for non-project requests (`project_id=null`)