### PR TITLE
fix: prevent cross-project heatmap model dropdown leakage

### DIFF
--- a/tests/test_frontend_heatmap_proxy_scoping.py
+++ b/tests/test_frontend_heatmap_proxy_scoping.py
@@ -32,3 +32,12 @@ def test_api_client_uses_project_scoped_models_endpoint_and_heatmap_query_param(
     assert "getProjectAvailableModels" in src
     assert "getHeatmapUrl" in src
     assert "params.set('project_id', projectId)" in src or 'params.set("project_id", projectId)' in src
+
+
+def test_page_heatmap_model_options_are_guarded_by_current_project_scope():
+    src = _read("frontend/src/app/page.tsx")
+
+    assert "projectAvailableModelsScopeId" in src
+    assert "projectAvailableModelsScopeId === currentProject.id" in src
+    assert "normalizedHeatmapModel" in src
+    assert "!scopedProjectModelIds.has(heatmapModel)" in src


### PR DESCRIPTION
## Summary
- guard project model state with a scope id so stale model arrays from a previous project are never rendered in the current project
- normalize heatmap model selection so an out-of-scope model id is discarded and replaced with the current project default
- add regression coverage asserting page-level project-scope guards for heatmap model options

## Testing
- `npm run check:model-scope`
- `npm run build`
- `source /tmp/medgemma-issue-36/.venv-test/bin/activate && pytest -q tests/test_frontend_heatmap_proxy_scoping.py`

Fixes Hilo-Hilo/med-gemma-hackathon#36