### PR TITLE
fix: harden panel fallbacks against unscoped model catalogs

### DIFF
--- a/frontend/src/components/panels/BatchAnalysisPanel.tsx
+++ b/frontend/src/components/panels/BatchAnalysisPanel.tsx
@@ -235,14 +235,22 @@ export function BatchAnalysisPanel({
       try {
         const details = await getProjectAvailableModels(currentProject.id);
         if (!cancelled && details.length > 0) {
-          setApiModelDetails(details);
           const primaryId = currentProject.prediction_target;
-          if (primaryId && details.some((d) => d.id === primaryId)) {
-            setSelectedModelIds([primaryId]);
-          } else {
-            setSelectedModelIds([details[0].id]);
+          const includesPrimary = !primaryId || details.some((d) => d.id === primaryId);
+
+          if (includesPrimary) {
+            setApiModelDetails(details);
+            if (primaryId && details.some((d) => d.id === primaryId)) {
+              setSelectedModelIds([primaryId]);
+            } else {
+              setSelectedModelIds([details[0].id]);
+            }
+            return;
           }
-          return;
+
+          console.warn(
+            "Project model details missing project primary target; falling back to project model IDs"
+          );
         }
       } catch {
         // fall through to ID endpoint + fallback

--- a/frontend/src/components/panels/ModelPicker.tsx
+++ b/frontend/src/components/panels/ModelPicker.tsx
@@ -165,8 +165,17 @@ export function ModelPicker({
         // Try the config-driven endpoint first
         const details = await getProjectAvailableModels(currentProject.id);
         if (!cancelled && details.length > 0) {
-          setApiModelDetails(details);
-          return;
+          const primaryId = currentProject.prediction_target;
+          const includesPrimary = !primaryId || details.some((d) => d.id === primaryId);
+
+          if (includesPrimary) {
+            setApiModelDetails(details);
+            return;
+          }
+
+          console.warn(
+            "Project model details missing project primary target; falling back to project model IDs"
+          );
         }
       } catch (err) {
         console.warn("Failed to fetch available models config:", err);
@@ -194,7 +203,7 @@ export function ModelPicker({
     return () => {
       cancelled = true;
     };
-  }, [currentProject.id]);
+  }, [currentProject.id, currentProject.prediction_target]);
 
   const fallbackModels = React.useMemo(
     () =>

--- a/frontend/src/components/panels/MultiModelPredictionPanel.tsx
+++ b/frontend/src/components/panels/MultiModelPredictionPanel.tsx
@@ -425,9 +425,16 @@ export function MultiModelPredictionPanel({
   const { currentProject } = useProject();
   const cancerTypeLabel = currentProject.cancer_type || "Cancer";
 
-  // Prefer project-scoped API models; otherwise use a safe project-derived fallback
-  const modelsToPreview = (availableModels && availableModels.length > 0)
-    ? availableModels.map((m) => ({ id: m.id, displayName: m.name, description: m.description }))
+  // Prefer project-scoped API models; otherwise use a safe project-derived fallback.
+  // Guard against stale/unscoped catalogs by requiring the current project's primary target.
+  const hasTrustedAvailableModels =
+    !!availableModels &&
+    availableModels.length > 0 &&
+    (!currentProject.prediction_target ||
+      availableModels.some((m) => m.id === currentProject.prediction_target));
+
+  const modelsToPreview = hasTrustedAvailableModels
+    ? availableModels!.map((m) => ({ id: m.id, displayName: m.name, description: m.description }))
     : getProjectFallbackPreviewModel(currentProject);
 
   // Update elapsed time during embedding


### PR DESCRIPTION
## Summary
- Hardened panel-side fallback handling so project model lists are only trusted when they include the current project's primary prediction target.
- Updated `ModelPicker` and `BatchAnalysisPanel` to fall through to project model-ID fallback when API model details look unscoped/stale.
- Updated `MultiModelPredictionPanel` preview to ignore untrusted `availableModels` and use project-derived fallback preview instead.

## Why
Prevents UI fallback paths from surfacing unrelated model catalogs (e.g. ovarian defaults) when project-scoped model fetches are stale, incomplete, or mismatched.

## Testing
- `npm run check:model-scope`
- `npm run lint`
- `npm run build`