### PR TITLE
fix: prevent project-scoped slide fallback to global embeddings

### DIFF
--- a/tests/test_backend_project_scoping_regressions.py
+++ b/tests/test_backend_project_scoping_regressions.py
@@ -36,3 +36,10 @@ def test_report_paths_resolve_project_specific_embeddings_before_processing():
     src = _main_source()
     assert "report_embeddings_dir = _resolve_project_embeddings_dir(" in src
     assert "_report_embeddings_dir = _resolve_project_embeddings_dir(" in src
+
+
+def test_project_scoped_slides_fail_closed_when_embeddings_are_missing_or_empty():
+    src = _main_source()
+    assert "returning 0 slides (no global fallback)" in src
+    assert "list_slides._cache[_cache_key] = {\"data\": [], \"ts\": time.time()}" in src
+    assert "_candidate_emb_dirs = [_fallback_embeddings_dir]" in src


### PR DESCRIPTION
## Summary
- stop `/api/slides` project-scoped requests from ever falling back to global slide lists
- return an empty list immediately when the selected project's embeddings directory does not exist
- keep project scoping strict while supporting both `<project>/embeddings/*.npy` and `<project>/embeddings/level0/*.npy`
- add a regression test to lock in the no-global-fallback behavior

## Testing
- `python3 -m py_compile src/enso_atlas/api/main.py src/enso_atlas/api/projects.py src/enso_atlas/api/project_routes.py tests/test_backend_project_scoping_regressions.py`
- `python3 scripts/validate_project_modularity.py`

Fixes Hilo-Hilo/med-gemma-hackathon#17
