### PR TITLE
fix: align 3-minute demo documentation with challenge requirements

### DIFF
--- a/docs/KAGGLE_SUBMISSION.md
+++ b/docs/KAGGLE_SUBMISSION.md
@@ -16,9 +16,10 @@ Platinum-based chemotherapy is the standard first-line treatment for ovarian can
 
 ## 3. Video Demo
 
-**Link:** [placeholder -- recording pending]
+**Link:** [placeholder -- recording pending upload]
 
-See `VIDEO_SCRIPT.md` for the planned demonstration walkthrough.
+Recording plan and required challenge coverage are documented in `VIDEO_SCRIPT.md`.
+Target export filename: `enso-atlas-3min-demo.mp4` (1080p, <= 3:00).
 
 ---
 

--- a/docs/SUBMISSION_CHECKLIST.md
+++ b/docs/SUBMISSION_CHECKLIST.md
@@ -10,7 +10,7 @@
 
 | Requirement | Status | Notes |
 |-------------|--------|-------|
-| 3-minute video demo | PENDING | Script finalized (VIDEO_SCRIPT.md), needs recording |
+| 3-minute video demo | PENDING | Requirement-mapped script finalized (VIDEO_SCRIPT.md), needs recording/upload |
 | 3-page technical writeup | DONE | SUBMISSION_WRITEUP.md updated and current |
 | Reproducible source code | DONE | GitHub repo at Hilo-Hilo/med-gemma-hackathon |
 | Kaggle Writeups upload | PENDING | Needs conversion and upload to Kaggle |

--- a/docs/VIDEO_SCRIPT.md
+++ b/docs/VIDEO_SCRIPT.md
@@ -1,191 +1,162 @@
 # Enso Atlas -- 3-Minute Video Demo Script
 
-**Target length:** 3:00 max
-**Frontend URL:** https://spark.tailcf1f80.ts.net (public via Tailscale Funnel)
-**Recording:** 1920x1080, 30fps, MP4
-**Browser:** Chrome, full screen, 80% zoom for density
+**Target length:** 2:50-3:00
+**Challenge:** MedGemma Impact Challenge (Kaggle)
+**Output format:** MP4, 1920x1080, 30fps
 
 ---
 
-## Core Message
+## Requirement Coverage Matrix
 
-Enso Atlas is a **modular, model-agnostic pathology platform** -- not a single-purpose demo. The HAI-DEF models showcase the system; the architecture supports any cancer type, any foundation model, any classification head.
-
-**Lead with the clinical result, not the UI.**
-
----
-
-## Timeline
-
-| Segment | Time | Duration | Focus |
-|---------|------|----------|-------|
-| Hook + Problem | 0:00-0:15 | 15s | Clinical need |
-| Dashboard + Case Selection | 0:15-0:30 | 15s | 208 slides, 3-panel layout |
-| Run Analysis + Prediction | 0:30-0:55 | 25s | AUC 0.907, multi-model |
-| Heatmap + Sensitivity | 0:55-1:20 | 25s | Attention overlay, model switching, sensitivity slider |
-| Evidence + Navigation | 1:20-1:35 | 15s | Top patches, click-to-navigate |
-| Outlier Detector | 1:35-1:50 | 15s | Flag unusual tissue regions |
-| Semantic Search (MedSigLIP) | 1:50-2:05 | 15s | Text-to-patch query |
-| AI Report (MedGemma) | 2:05-2:20 | 15s | Structured tumor board report |
-| Modularity + Deployment | 2:20-2:45 | 25s | YAML config, plug-and-play, Mac mini feasibility |
-| Closing | 2:45-3:00 | 15s | On-prem, evidence-based, open platform |
+| Challenge requirement | Covered at |
+|---|---|
+| 1) Problem statement (on-prem pathology evidence engine for treatment response prediction) | 0:00-0:20 |
+| 2) Live demo (select/upload WSI -> view tiles -> run analysis -> prediction) | 0:20-0:55 |
+| 3) Semantic search with MedSigLIP | 1:20-1:40 |
+| 4) Clinical report generation with MedGemma | 2:00-2:25 |
+| 5) Similar case retrieval | 1:40-2:00 |
+| 6) Heatmap visualization | 0:55-1:20 |
+| 7) Technical architecture overview (Path Foundation + MedGemma + MedSigLIP) | 2:25-2:50 |
 
 ---
 
-## Script
+## Timeline (3:00 max)
 
-### 0:00-0:15 -- HOOK AND PROBLEM
-
-**Narration:**
-"30% of ovarian cancer patients receive platinum chemotherapy that won't work for them. By the time clinicians know, the patient has endured months of toxic side effects. What if a standard tissue slide -- already collected during biopsy -- could predict who will respond before treatment begins?"
-
-**Screen:**
-- Black screen with text: "30% of patients receive ineffective chemotherapy"
-- Fade to Enso Atlas dashboard
-
----
-
-### 0:15-0:30 -- DASHBOARD AND CASE SELECTION
-
-**Narration:**
-"Enso Atlas processes whole-slide histopathology images into actionable evidence. Here we have 208 ovarian cancer cases from TCGA. Selecting a slide loads the full-resolution image with over 6,000 tissue patches."
-
-**Screen:**
-- Show 3-panel layout: case list (left), WSI viewer (center), results (right)
-- Scroll through case list showing thumbnails and metadata
-- Click slide_000 -- WSI loads in viewer with minimap
+| Segment | Time | Duration |
+|---|---|---|
+| Hook + Problem statement | 0:00-0:20 | 20s |
+| Live workflow: WSI selection, tile viewing, run analysis, prediction | 0:20-0:55 | 35s |
+| Heatmap visualization | 0:55-1:20 | 25s |
+| Semantic search (MedSigLIP) | 1:20-1:40 | 20s |
+| Similar case retrieval | 1:40-2:00 | 20s |
+| Clinical report generation (MedGemma) | 2:00-2:25 | 25s |
+| Technical architecture overview | 2:25-2:50 | 25s |
+| Closing | 2:50-3:00 | 10s |
 
 ---
 
-### 0:30-0:55 -- RUN ANALYSIS AND PREDICTION
+## Script + On-Screen Actions
 
-**Narration:**
-"Running analysis triggers five specialized TransMIL models in parallel. Our platinum sensitivity model achieves AUC 0.907 -- trained on 199 TCGA slides using Path Foundation embeddings. Each model returns a score, confidence estimate, and the attention weights that produced it."
+### 0:00-0:20 -- Hook + problem statement
 
-**Screen:**
-- Click "Run Analysis" (or show cached results loading instantly)
-- Prediction panel: "Sensitive -- 100% -- High Confidence"
-- Scroll to Multi-Model Analysis: all 5 models with scores
-- Point out AUC badge on Platinum Sensitivity model card
+**Narration**
+"Platinum chemotherapy is standard for ovarian cancer, but many patients still receive treatment that does not work for them. Enso Atlas is an on-prem pathology evidence engine that predicts treatment response from whole-slide images and shows exactly what evidence drove each prediction."
 
----
-
-### 0:55-1:20 -- ATTENTION HEATMAP AND SENSITIVITY CONTROL
-
-**Narration:**
-"The attention heatmap reveals which tissue regions drove the prediction. Each pixel represents one 224-by-224 patch. The sensitivity slider controls visibility of low-attention regions -- pulling it left reveals the full attention landscape, while pushing right isolates the most discriminative tissue."
-
-**Screen:**
-- Toggle "Show overlay" ON -- heatmap appears over tissue
-- Toggle "Heatmap only" -- black background, attention map visible
-- Switch model dropdown from Platinum Sensitivity to 3-Year Survival -- heatmap updates
-- Drag sensitivity slider from 0.7 to 0.2 -- low-attention patches become visible
-- Drag back to 1.0 -- only hot spots remain
-- Toggle patch grid ON briefly to show 224px boundaries
+**Screen actions**
+- Start on title slide: "Enso Atlas -- On-Prem Pathology Evidence Engine"
+- Cut to dashboard with one case already selected
 
 ---
 
-### 1:20-1:35 -- EVIDENCE PATCHES AND NAVIGATION
+### 0:20-0:55 -- Live workflow (select/upload WSI -> tiles -> run analysis -> prediction)
 
-**Narration:**
-"The evidence panel extracts the highest-attention patches as a clickable gallery. Each shows its normalized weight. Clicking a patch navigates directly to that region on the slide at high magnification."
+**Narration**
+"Here is a live case workflow. We select a whole-slide image from the case list, load its tiled viewer, and run analysis. The model returns a treatment-response prediction with confidence and supporting evidence."
 
-**Screen:**
-- Scroll to Evidence Patches in right panel
-- Click a top-attention patch -- WSI zooms to that location
-- Show the scale bar and magnification updating
-
----
-
-### 1:35-1:50 -- OUTLIER TISSUE DETECTOR
-
-**Narration:**
-"The outlier detector uses Path Foundation embeddings to flag morphologically unusual patches -- potential artifacts, rare tissue patterns, or regions worth a second look. No additional model training required; it operates directly on the foundation model's feature space."
-
-**Screen:**
-- Scroll to Outlier Tissue Detector panel
-- Click "Detect Outliers" with threshold at 2.0 SD
-- Show outlier count and statistics
-- Toggle "Show as Heatmap" -- amber/red overlay on WSI
-- Click an outlier patch to navigate
+**Screen actions**
+- Open **Slide Manager** or left case list and select a WSI (or show quick upload if available)
+- Pan/zoom in OpenSeadragon to show tile loading
+- Click **Run Analysis**
+- Highlight prediction card (class + confidence)
 
 ---
 
-### 1:50-2:05 -- SEMANTIC SEARCH (MedSigLIP)
+### 0:55-1:20 -- Heatmap visualization
 
-**Narration:**
-"MedSigLIP enables natural language tissue search. Type 'tumor infiltrating lymphocytes' and retrieve matching regions ranked by semantic similarity. Pathologists can validate model predictions against their own expertise."
+**Narration**
+"The attention heatmap highlights tissue regions that most influenced the prediction. This gives clinicians spatial evidence instead of a black-box score."
 
-**Screen:**
-- Type "tumor infiltrating lymphocytes" in Semantic Search
-- Results appear with similarity scores
-- Click a match to navigate on WSI
-
----
-
-### 2:05-2:20 -- AI REPORT (MedGemma)
-
-**Narration:**
-"MedGemma generates a structured tumor board report describing observed morphology, clinical significance, and limitations. Reports include mandatory research-only disclaimers and export as PDF."
-
-**Screen:**
-- Click "Generate Report" or show cached report
-- Scroll through report sections: morphology, clinical significance, limitations
-- Click "Export PDF"
+**Screen actions**
+- Toggle heatmap overlay ON
+- Adjust sensitivity slider once (low to high)
+- Briefly switch model to show heatmap updates per endpoint
 
 ---
 
-### 2:20-2:45 -- MODULARITY AND DEPLOYMENT
+### 1:20-1:40 -- Semantic search (MedSigLIP)
 
-**Narration:**
-"Enso Atlas is a platform, not a single-purpose tool. Adding a new cancer type requires one YAML configuration block -- define the project, assign models, toggle features. Foundation models are swappable: replace Path Foundation with UNI, CONCH, or any custom encoder. Classification heads are pluggable: drop in weights, register in config. The entire stack deploys via Docker Compose and runs on hardware as modest as a Mac mini with 16 gigabytes of RAM."
+**Narration**
+"With MedSigLIP, users can search tissue morphology in natural language. For example, we query 'tumor infiltrating lymphocytes' and retrieve matching patches ranked by similarity."
 
-**Screen:**
-- Show `config/projects.yaml` in a code editor: foundation_models section, classification_models section, project definition
-- Highlight: changing `foundation_model: path_foundation` to `foundation_model: uni_v2`
-- Show terminal: `docker compose up -d` (3 services starting)
-- Show health check JSON: model_loaded: true, slides_available: 208
-- Quick flash of the architecture: Path Foundation -> TransMIL -> Evidence -> MedGemma Report
+**Screen actions**
+- Enter text query in semantic search box
+- Show top matches with similarity scores
+- Click one result to jump viewer to that region
 
 ---
 
-### 2:45-3:00 -- CLOSING
+### 1:40-2:00 -- Similar case retrieval
 
-**Narration:**
-"Every prediction comes with evidence. Every model is replaceable. Every byte of patient data stays on-premise. Enso Atlas turns pathology AI into something clinicians can actually trust."
+**Narration**
+"Enso Atlas also retrieves morphologically similar historical cases, helping contextualize each prediction against reference patients."
 
-**Screen:**
-- Return to main dashboard with heatmap visible and report in right panel
-- Fade to:
-  - "Enso Atlas" title
-  - "github.com/Hilo-Hilo/med-gemma-hackathon"
-  - "Built with Path Foundation, MedGemma, MedSigLIP"
+**Screen actions**
+- Open similar cases panel
+- Show top retrieved cases and similarity/confidence metadata
+- Click a retrieved case briefly
+
+---
+
+### 2:00-2:25 -- Clinical report generation (MedGemma)
+
+**Narration**
+"MedGemma generates a structured clinical summary grounded in model outputs and visual evidence. The report is exportable for downstream review workflows."
+
+**Screen actions**
+- Click **Generate Report** (or show cached report if pre-generated)
+- Scroll report sections: morphology, interpretation, limitations/disclaimer
+- Click **Export PDF**
+
+---
+
+### 2:25-2:50 -- Technical architecture overview
+
+**Narration**
+"Under the hood, Path Foundation creates patch embeddings, MedSigLIP powers text-to-patch semantic retrieval, and MedGemma handles report generation. These components run behind a FastAPI plus Next.js stack for local, auditable deployment."
+
+**Screen actions**
+- Show architecture slide or `README.md` architecture diagram
+- Call out: **Path Foundation**, **MedSigLIP**, **MedGemma**
+- Briefly show local deployment command (`docker compose -f docker/docker-compose.yaml up -d`)
+
+---
+
+### 2:50-3:00 -- Closing
+
+**Narration**
+"Enso Atlas keeps pathology AI on-prem, evidence-based, and clinically reviewable -- from slide-level prediction to interpretable heatmaps, semantic search, similar-case context, and structured reporting."
+
+**Screen actions**
+- Return to dashboard with prediction + heatmap visible
+- End card with repo URL: `github.com/Hilo-Hilo/med-gemma-hackathon`
 
 ---
 
 ## Recording Checklist
 
-- [ ] Pre-load slide_000 with cached results (avoid cold-start wait)
-- [ ] Pre-warm MedSigLIP cache for "tumor infiltrating lymphocytes" query
-- [ ] Pre-generate at least one clinical report
-- [ ] Clear heatmap cache for slide_000 if demonstrating live generation
-- [ ] Test sensitivity slider with 3-Year Survival model (sparse attention = dramatic effect)
-- [ ] Chrome full-screen, 80% zoom, dark mode OFF (light mode photographs better)
-- [ ] Verify public URL works: https://spark.tailcf1f80.ts.net
-- [ ] Record narration separately for clean audio, overlay in post
-- [ ] Total runtime target: 2:50-3:00 (leave buffer for cuts)
+### Pre-record
+- [ ] Backend healthy (`GET /api/health`)
+- [ ] Frontend loaded and responsive
+- [ ] Demo slide pre-selected and cached
+- [ ] One MedGemma report pre-generated (backup for timing)
+- [ ] Semantic search query tested (`tumor infiltrating lymphocytes`)
+- [ ] Similar-case panel verified
+- [ ] Architecture slide/window prepared
 
-## Key Numbers to Mention
+### Recording
+- [ ] Keep narration pace at ~130-145 wpm
+- [ ] Avoid dead time (pre-warm heavy endpoints)
+- [ ] Keep total runtime <= 3:00
 
-- AUC 0.907 (platinum sensitivity, full dataset)
-- 208 slides, 5 models, 3 HAI-DEF foundation models
-- 6,934 tissue patches per slide (level 0, 224x224)
-- Runs on Mac mini (16 GB minimum)
-- Docker Compose: 3 containers, single command deployment
+### Export
+- [ ] MP4 (H.264), 1080p, 30fps
+- [ ] Audio clear and normalized
+- [ ] Filename: `enso-atlas-3min-demo.mp4`
 
-## What NOT to Say
+---
 
-- Don't call it a "wrapper" or "interface" -- it's an evidence engine
-- Don't spend time on UI polish details -- focus on clinical workflow and modularity
-- Don't mention specific limitations unless asked (save for writeup)
-- Don't use "groundbreaking", "revolutionary", "game-changing"
+## Notes
+
+- If live inference is slow, use cached results and state that the flow is identical in production.
+- Prioritize required challenge coverage over extra UI features.
+- Keep claims factual and aligned with repo metrics.


### PR DESCRIPTION
## Summary
- rewrote `docs/VIDEO_SCRIPT.md` into a strict 3-minute storyboard mapped to all required challenge items
- added a requirement coverage matrix with timestamps for each mandated demo topic
- updated submission docs to reference the finalized recording plan and expected video artifact name

## Testing
- `git diff --check`
- `npx --yes markdownlint-cli docs/VIDEO_SCRIPT.md docs/KAGGLE_SUBMISSION.md docs/SUBMISSION_CHECKLIST.md` (fails due existing repository-wide markdown style baseline; no functional/doc build tooling failures introduced)
