### PR TITLE
Fix prod API proxy: default frontend rewrites to backend :8003

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || (
+  process.env.NODE_ENV === "production"
+    ? "http://127.0.0.1:8003"
+    : "http://127.0.0.1:8000"
+);
+
 const nextConfig = {
   // Enable React strict mode for development
   reactStrictMode: true,
@@ -38,7 +44,7 @@ const nextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: `${process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:8000'}/api/:path*`, // Local backend default; set NEXT_PUBLIC_API_URL to :8003 for Docker backend
+        destination: `${apiBaseUrl}/api/:path*`,
       },
     ]
   },


### PR DESCRIPTION
## Why
Project page currently fails on production with `Failed to fetch projects: 404` because frontend API rewrite fallback defaulted to `127.0.0.1:8000`, while the deployed backend is on `:8003`.

## Change
- `frontend/next.config.mjs`
  - Introduce `apiBaseUrl`:
    - use `NEXT_PUBLIC_API_URL` when explicitly set
    - otherwise default to:
      - `http://127.0.0.1:8003` in production
      - `http://127.0.0.1:8000` in local/dev

This preserves local developer defaults while fixing deployed production routing.

## Validation
- `pytest -q` → 109 passed
- `cd frontend && npm run lint` (warnings only)

