### PR TITLE
Fix semantic-search visibility + idle disconnected-banner recovery

### DIFF
--- a/tests/test_issue91_semantic_search_and_connection_recovery.py
+++ b/tests/test_issue91_semantic_search_and_connection_recovery.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_issue91_oncologist_sidebar_includes_semantic_search_tab():
+    src = _read("frontend/src/app/page.tsx")
+
+    assert '{ value: "semantic-search", label: "Semantic Search" }' in src
+
+
+def test_issue91_main_page_connection_recovers_after_idle_events():
+    src = _read("frontend/src/app/page.tsx")
+
+    assert 'document.addEventListener("visibilitychange", handleVisibilityChange);' in src
+    assert 'window.addEventListener("focus", handleWindowFocus);' in src
+    assert 'window.addEventListener("online", handleWindowFocus);' in src
+    assert "let failureStreak = 0;" in src
+    assert "failureStreak >= 2" in src
+
+
+def test_issue91_projects_page_connection_recovers_after_idle_events():
+    src = _read("frontend/src/app/projects/page.tsx")
+
+    assert 'document.addEventListener("visibilitychange", handleVisibilityChange);' in src
+    assert 'window.addEventListener("focus", handleWindowFocus);' in src
+    assert 'window.addEventListener("online", handleWindowFocus);' in src
+    assert "let failureStreak = 0;" in src
+    assert "failureStreak >= 2" in src


### PR DESCRIPTION
## Summary
Addresses three user-visible regressions:
1) Semantic search missing from the right-side tool tabs in oncologist mode
2) Disconnected banner lingering after idle/background due delayed health re-check
3) Transient single health-check failures causing unnecessary disconnected state

## Changes
- `frontend/src/app/page.tsx`
  - Add `Semantic Search` tab to oncologist right-sidebar tools
  - Improve health connectivity loop:
    - immediate re-check on `visibilitychange`, `focus`, and `online`
    - require 2 consecutive health failures before marking disconnected
- `frontend/src/app/projects/page.tsx`
  - Apply same idle/background connectivity recovery logic for projects page header status
- `tests/test_issue91_semantic_search_and_connection_recovery.py`
  - Add regression checks for semantic-search tab presence and connectivity event hooks

## Validation
- `pytest -q tests/test_issue91_semantic_search_and_connection_recovery.py tests/test_issue86_remove_right_panel.py` → 20 passed
- `pytest -q` → 112 passed
- `cd frontend && npm run lint` (warnings only, no errors)

