### PR TITLE
Semantic search: click selected patch again to deselect

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1645,6 +1645,11 @@ function HomePage() {
     setTargetCoordinates({ ...coords });
   }, []);
 
+  const handlePatchDeselect = useCallback(() => {
+    setSelectedPatchId(undefined);
+    setTargetCoordinates(null);
+  }, []);
+
   const handleReportEvidenceClick = useCallback((coords: PatchCoordinates) => {
     // Ensure the clicked evidence is visible in the full WSI viewer.
     if (userViewMode === "oncologist") {
@@ -2368,6 +2373,7 @@ function HomePage() {
           isSearching={isSearching}
           error={searchError}
           onPatchClick={handlePatchClick}
+          onPatchDeselect={handlePatchDeselect}
           selectedPatchId={selectedPatchId}
           inputRef={searchInputRef}
           onClearResults={() => {
@@ -2375,6 +2381,7 @@ function HomePage() {
             setSemanticResults([]);
             setSearchError(null);
             setIsSearching(false);
+            handlePatchDeselect();
           }}
         />
       );

--- a/tests/test_issue94_semantic_search_deselect.py
+++ b/tests/test_issue94_semantic_search_deselect.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_issue94_semantic_panel_supports_patch_deselect_callback():
+    src = _read("frontend/src/components/panels/SemanticSearchPanel.tsx")
+
+    assert "onPatchDeselect?: () => void;" in src
+    assert "if (isSelected) {" in src
+    assert "onPatchDeselect?.();" in src
+    assert "Click again to deselect" in src
+
+
+def test_issue94_main_page_exposes_handle_patch_deselect():
+    src = _read("frontend/src/app/page.tsx")
+
+    assert "const handlePatchDeselect = useCallback(() => {" in src
+    assert "setSelectedPatchId(undefined);" in src
+    assert "setTargetCoordinates(null);" in src
+
+
+def test_issue94_semantic_panel_wiring_uses_deselect_callback():
+    src = _read("frontend/src/app/page.tsx")
+
+    assert "onPatchDeselect={handlePatchDeselect}" in src
+    assert "handlePatchDeselect();" in src


### PR DESCRIPTION
## Summary
Adds a deselect interaction for semantic-search patch results.

## What changed
- `frontend/src/components/panels/SemanticSearchPanel.tsx`
  - Added optional `onPatchDeselect` callback.
  - Clicking an already-selected patch now deselects it instead of re-jumping.
  - Added tooltip/copy hint for deselection behavior.
  - Added inline tip when a patch is selected.
- `frontend/src/app/page.tsx`
  - Added `handlePatchDeselect()` to clear both:
    - `selectedPatchId`
    - `targetCoordinates`
  - Wired `onPatchDeselect` into `SemanticSearchPanel`.
  - Clearing semantic search results also clears selected patch highlight.
- `tests/test_issue94_semantic_search_deselect.py`
  - Regression checks for new deselect wiring and state clearing.

## Validation
- `pytest -q tests/test_issue94_semantic_search_deselect.py tests/test_semantic_search_frontend_patch_preview_regression.py` → 6 passed
- `pytest -q` → 120 passed
- `cd frontend && npm run lint` (warnings only)

