### PR TITLE
Fix demo mode step skipping and startup latency (#96)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -119,6 +119,13 @@ const RIGHT_PANEL_ICONS: Record<RightSidebarPanelKey, React.ElementType> = {
   "outlier-detector": AlertTriangle,
 };
 
+const DEMO_RIGHT_PANEL_BY_STEP: Partial<Record<number, RightSidebarPanelKey>> = {
+  3: "prediction",
+  4: "evidence",
+  5: "similar-cases",
+  6: "medgemma",
+};
+
 function RightSidebarTabs({
   options,
   activePanel,
@@ -292,6 +299,29 @@ function HomePage() {
   const handleDemoModeToggle = useCallback(() => {
     setDemoMode((prev) => !prev);
   }, []);
+
+  const handleDemoStepChange = useCallback(
+    (step: number) => {
+      const normalizedStep = Math.max(0, step);
+
+      // Keep demo in oncologist + WSI mode so targets are deterministic.
+      handleUserViewModeChange("oncologist");
+      setViewMode("wsi");
+
+      if (normalizedStep <= 1) {
+        leftPanelRef.current?.expand?.();
+        setLeftSidebarOpen(true);
+        setMobilePanelTab("slides");
+      }
+
+      const targetRightPanel = DEMO_RIGHT_PANEL_BY_STEP[normalizedStep];
+      if (targetRightPanel) {
+        setActiveRightPanel(targetRightPanel);
+        setMobilePanelTab("results");
+      }
+    },
+    [handleUserViewModeChange]
+  );
 
   // Mock analysis result overlay for demo mode (analysisResult is owned by useAnalysis hook)
   const [demoAnalysisResult, setDemoAnalysisResult] = useState<import("@/types").AnalysisResponse | null>(null);
@@ -2712,6 +2742,7 @@ function HomePage() {
       <DemoMode
         isActive={demoMode}
         onClose={() => setDemoMode(false)}
+        onStepChange={handleDemoStepChange}
       />
 
       {/* Welcome Modal */}

--- a/frontend/src/components/panels/AnalysisControls.tsx
+++ b/frontend/src/components/panels/AnalysisControls.tsx
@@ -147,6 +147,7 @@ export function AnalysisControls({
                   isLoading={isAnalyzing}
                   className="w-full border-sky-300 bg-sky-100 text-sky-900 hover:bg-sky-200"
                   data-action="run-analysis"
+                  data-demo="analyze-button"
                 >
                   {isGeneratingEmbeddings
                     ? "Generating Embeddings..."

--- a/tests/test_issue96_demo_mode_reliability.py
+++ b/tests/test_issue96_demo_mode_reliability.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_issue96_demo_mode_starts_after_first_target_not_all_targets():
+    src = _read("frontend/src/components/demo/DemoMode.tsx")
+
+    assert "const firstStepSelector = getStepSelector(0);" in src
+    assert "tourSteps.every" not in src
+
+
+def test_issue96_demo_mode_uses_bounded_single_lane_target_retry():
+    src = _read("frontend/src/components/demo/DemoMode.tsx")
+
+    assert "const MAX_TARGET_RETRY_ATTEMPTS = 8;" in src
+    assert "if (activeRetry.step === missingStep && activeRetry.timer)" in src
+    assert "if (retryState.attempts >= MAX_TARGET_RETRY_ATTEMPTS)" in src
+    assert "if (type === EVENTS.STEP_BEFORE)" in src
+
+
+def test_issue96_page_wires_demo_step_preconditions_and_panel_mapping():
+    src = _read("frontend/src/app/page.tsx")
+
+    assert "const DEMO_RIGHT_PANEL_BY_STEP" in src
+    assert '3: "prediction"' in src
+    assert '4: "evidence"' in src
+    assert '5: "similar-cases"' in src
+    assert '6: "medgemma"' in src
+    assert "leftPanelRef.current?.expand?.();" in src
+    assert "onStepChange={handleDemoStepChange}" in src
+
+
+def test_issue96_analysis_button_has_demo_target_selector():
+    src = _read("frontend/src/components/panels/AnalysisControls.tsx")
+
+    assert 'data-demo="analyze-button"' in src


### PR DESCRIPTION
## Summary
Fixes #96.

This PR hardens guided demo mode sequencing and startup behavior.

### What changed
- **Demo startup latency fix** (`frontend/src/components/demo/DemoMode.tsx`)
  - Removed the global wait-for-all-targets gate.
  - Demo now starts once **step 1 target** is ready (with bounded readiness checks), so users see the first tooltip quickly.

- **Deterministic tour sequencing + stable target recovery** (`frontend/src/components/demo/DemoMode.tsx`)
  - Added a single-lane bounded retry state machine for `TARGET_NOT_FOUND`.
  - Prevents overlapping retry timers from issuing duplicate step transitions.
  - Uses explicit step clamping and controlled step transitions for next/back.
  - Calls `onStepChange` on `STEP_BEFORE` so the page can satisfy per-step UI preconditions before rendering each tooltip.

- **Per-step UI preconditions wired in page** (`frontend/src/app/page.tsx`)
  - Added `handleDemoStepChange` and `DEMO_RIGHT_PANEL_BY_STEP` mapping:
    - step 3 -> prediction
    - step 4 -> evidence
    - step 5 -> similar cases
    - step 6 -> report (medgemma)
  - Keeps demo in oncologist + WSI mode for deterministic targets.
  - Expands left sidebar for early steps so slide selector targets remain visible.
  - Passes `onStepChange={handleDemoStepChange}` into `DemoMode`.

- **Missing selector fix for step 2** (`frontend/src/components/panels/AnalysisControls.tsx`)
  - Added `data-demo="analyze-button"` to Run Analysis button so the step target exists.

- **Regression tests** (`tests/test_issue96_demo_mode_reliability.py`)
  - Added source-level regression checks for:
    - first-step startup gating (no all-target gate)
    - bounded single-lane target retry behavior
    - per-step panel precondition wiring
    - analyze button demo selector presence

## Validation
- `pytest -q` ✅ (124 passed)
- `npm run lint` ✅ (passes; pre-existing warnings only)
- `npx tsc --noEmit` ✅
