### PR TITLE
Fix demo mode step-4 crash (null nodeName)

### DIFF
--- a/tests/test_issue98_demo_mode_step4_node_guard.py
+++ b/tests/test_issue98_demo_mode_step4_node_guard.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_issue98_demo_mode_defers_step_transition_after_step_after_event():
+    src = _read("frontend/src/components/demo/DemoMode.tsx")
+
+    assert "requestAnimationFrame(() => setTourStep(currentIndex + 1));" in src
+    assert "requestAnimationFrame(() => setTourStep(currentIndex - 1));" in src
+
+
+def test_issue98_demo_mode_disables_joyride_scrolling_side_effects():
+    src = _read("frontend/src/components/demo/DemoMode.tsx")
+
+    assert "disableScrolling" in src
+
+
+def test_issue98_set_tour_step_updates_index_ref_without_direct_onstepchange_call():
+    src = _read("frontend/src/components/demo/DemoMode.tsx")
+
+    assert "stepIndexRef.current = bounded;" in src
+    assert "const setTourStep = useCallback((nextStep: number) => {" in src


### PR DESCRIPTION
## Summary
Fixes the runtime crash reported when advancing around demo step 4:
`TypeError: Cannot read properties of null (reading 'nodeName')`.

## Root cause
During `STEP_AFTER`, we were transitioning steps and mutating panel visibility synchronously while Joyride/Floater was still settling the previous target. In some transitions this produced a transient null target path inside Joyride/Floater internals.

## Changes
- `frontend/src/components/demo/DemoMode.tsx`
  - `setTourStep` now updates step state/index ref only (no direct `onStepChange` side-effect inside transition helper).
  - Defer step transitions from `STEP_AFTER` with `requestAnimationFrame` so Joyride can finish previous tooltip teardown first.
  - Enable `disableScrolling` on Joyride to avoid scroll-parent churn during dynamic panel remounts.
- Added regression checks:
  - `tests/test_issue98_demo_mode_step4_node_guard.py`

## Validation
- `pytest -q tests/test_issue96_demo_mode_reliability.py tests/test_issue98_demo_mode_step4_node_guard.py` → 7 passed
- `pytest -q` → 127 passed
- `cd frontend && npm run lint` (warnings only)

Ref: #96
