### PR TITLE
Fix demo mode null-target crashes by using stable right-tab step anchors

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -145,6 +145,7 @@ function RightSidebarTabs({
             <button
               key={opt.value}
               role="tab"
+              data-demo={`right-tab-${opt.value}`}
               aria-selected={isActive}
               aria-label={opt.label}
               title={opt.label}

--- a/frontend/src/components/demo/DemoMode.tsx
+++ b/frontend/src/components/demo/DemoMode.tsx
@@ -233,7 +233,7 @@ const tourSteps: Step[] = [
     },
   },
   {
-    target: '[data-demo="prediction-panel"]',
+    target: '[data-demo="right-tab-prediction"]',
     title: "Treatment Response Prediction",
     content: (
       <div className="space-y-2">
@@ -258,7 +258,7 @@ const tourSteps: Step[] = [
     },
   },
   {
-    target: '[data-demo="evidence-panel"]',
+    target: '[data-demo="right-tab-evidence"]',
     title: "Evidence Patches",
     content: (
       <div className="space-y-2">
@@ -283,7 +283,7 @@ const tourSteps: Step[] = [
     },
   },
   {
-    target: '[data-demo="similar-cases"]',
+    target: '[data-demo="right-tab-similar-cases"]',
     title: "Similar Historical Cases",
     content: (
       <div className="space-y-2">
@@ -308,7 +308,7 @@ const tourSteps: Step[] = [
     },
   },
   {
-    target: '[data-demo="report-panel"]',
+    target: '[data-demo="right-tab-medgemma"]',
     title: "Clinical Report Generation",
     content: (
       <div className="space-y-2">

--- a/tests/test_issue99_demo_mode_stable_tab_targets.py
+++ b/tests/test_issue99_demo_mode_stable_tab_targets.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_issue99_demo_steps_target_stable_right_sidebar_tabs():
+    src = _read("frontend/src/components/demo/DemoMode.tsx")
+
+    assert '[data-demo="right-tab-prediction"]' in src
+    assert '[data-demo="right-tab-evidence"]' in src
+    assert '[data-demo="right-tab-similar-cases"]' in src
+    assert '[data-demo="right-tab-medgemma"]' in src
+
+    # Tour should no longer anchor to panel bodies that mount/unmount during tab switches.
+    assert '[data-demo="prediction-panel"]' not in src
+    assert '[data-demo="evidence-panel"]' not in src
+    assert '[data-demo="similar-cases"]' not in src
+    assert '[data-demo="report-panel"]' not in src
+
+
+def test_issue99_right_sidebar_tabs_expose_demo_hooks_for_each_panel_button():
+    src = _read("frontend/src/app/page.tsx")
+
+    assert 'data-demo={`right-tab-${opt.value}`}' in src


### PR DESCRIPTION
## Summary
Follow-up fix for the persistent demo-mode `nodeName` null crash.

## Root issue
Demo steps 4-7 were anchored to panel-body selectors (`prediction-panel`, `evidence-panel`, `similar-cases`, `report-panel`) that mount/unmount as the right panel changes. During Joyride transitions, these transient targets can disappear and trigger null-target failures in Joyride/Floater internals.

## Fix
- Add stable demo hooks to right sidebar tab buttons:
  - `data-demo={\`right-tab-${opt.value}\`}`
- Update demo steps 4-7 to target these stable tab elements instead of remounting panel bodies:
  - `right-tab-prediction`
  - `right-tab-evidence`
  - `right-tab-similar-cases`
  - `right-tab-medgemma`

This keeps tour anchors mounted throughout tab transitions while still switching content via step preconditions.

## Tests
- Added `tests/test_issue99_demo_mode_stable_tab_targets.py`
- Ran:
  - `pytest -q tests/test_issue96_demo_mode_reliability.py tests/test_issue98_demo_mode_step4_node_guard.py tests/test_issue99_demo_mode_stable_tab_targets.py`
  - `pytest -q`
  - `cd frontend && npm run lint` (warnings only)

