### PR TITLE
feat(dev): isolated DGX dev stack for perf lab

### DIFF
--- a/docker/.env.dev.example
+++ b/docker/.env.dev.example
@@ -1,0 +1,27 @@
+# Enso Atlas dev stack environment template
+# Copy to docker/.env.dev and adjust for your DGX/local setup.
+
+# SAFETY: Keep this pointed at dev resources only.
+# Do NOT run schema migrations against production DB without explicit approval.
+
+# Optional GPU controls
+NVIDIA_VISIBLE_DEVICES=all
+NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# Optional offline mode once models are cached
+TRANSFORMERS_OFFLINE=0
+HF_HUB_OFFLINE=0
+
+# Optional host path overrides for dev stack mounts
+ENSO_DEV_DATA_DIR=../data-dev
+ENSO_DEV_OUTPUTS_DIR=../outputs-dev
+HF_CACHE_DIR=../.cache/huggingface
+ENSO_MODELS_DIR=../models
+ENSO_CONFIG_DIR=../config
+ENSO_SRC_DIR=../src
+
+# Dev DB defaults (matches docker-compose.dev.yaml service atlas-dev-db)
+DEV_POSTGRES_DB=enso_atlas_dev
+DEV_POSTGRES_USER=enso_dev
+DEV_POSTGRES_PASSWORD=enso_dev_2026
+DEV_DATABASE_URL=postgresql://enso_dev:enso_dev_2026@atlas-dev-db:5432/enso_atlas_dev

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -1,0 +1,71 @@
+# Enso Atlas isolated development stack (performance lab / DGX)
+# Safety guardrail: this stack must never point to production databases or services.
+# No schema migrations against production DB are allowed without explicit approval.
+services:
+  enso-atlas-dev:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    container_name: enso-atlas-dev
+    environment:
+      NVIDIA_VISIBLE_DEVICES: "${NVIDIA_VISIBLE_DEVICES:-all}"
+      NVIDIA_DRIVER_CAPABILITIES: "${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}"
+      ENSO_CONFIG: /app/config/default.yaml
+      TRANSFORMERS_CACHE: /app/cache/huggingface
+      HF_HOME: /app/cache/huggingface
+      MIL_ARCHITECTURE: transmil
+      MIL_THRESHOLD_CONFIG: /app/models/threshold_config.json
+      TRANSFORMERS_OFFLINE: "${TRANSFORMERS_OFFLINE:-0}"
+      HF_HUB_OFFLINE: "${HF_HUB_OFFLINE:-0}"
+
+      # Dev-only DB endpoint. Do not connect this stack to production DB.
+      DATABASE_URL: "${DEV_DATABASE_URL:-postgresql://enso_dev:enso_dev_2026@atlas-dev-db:5432/enso_atlas_dev}"
+      DB_ENVIRONMENT: dev
+      DB_MIGRATIONS_REQUIRE_APPROVAL: "true"
+      DB_SAFETY_NOTICE: "NO_SCHEMA_MIGRATIONS_AGAINST_PROD_WITHOUT_APPROVAL"
+    volumes:
+      - ${ENSO_DEV_DATA_DIR:-../data-dev}:/app/data
+      - ${ENSO_DEV_OUTPUTS_DIR:-../outputs-dev}:/app/outputs
+      - atlas-dev-cache:/app/cache
+      - ${HF_CACHE_DIR:-../.cache/huggingface}:/root/.cache/huggingface
+      - ${ENSO_MODELS_DIR:-../models}:/app/models
+      - ${ENSO_CONFIG_DIR:-../config}:/app/config
+      - ${ENSO_SRC_DIR:-../src}:/app/src:ro
+    ports:
+      - "17862:7860"
+      - "18003:8000"
+    restart: unless-stopped
+    depends_on:
+      atlas-dev-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+
+  atlas-dev-db:
+    image: postgres:16
+    container_name: atlas-dev-db
+    environment:
+      POSTGRES_DB: "${DEV_POSTGRES_DB:-enso_atlas_dev}"
+      POSTGRES_USER: "${DEV_POSTGRES_USER:-enso_dev}"
+      POSTGRES_PASSWORD: "${DEV_POSTGRES_PASSWORD:-enso_dev_2026}"
+    volumes:
+      - atlas-dev-pgdata:/var/lib/postgresql/data
+    ports:
+      - "15433:5432"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DEV_POSTGRES_USER:-enso_dev} -d ${DEV_POSTGRES_DB:-enso_atlas_dev}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+volumes:
+  atlas-dev-cache:
+    driver: local
+  atlas-dev-pgdata:
+    driver: local

--- a/docs/dev-stack-runbook.md
+++ b/docs/dev-stack-runbook.md
@@ -1,0 +1,105 @@
+# Enso Atlas Isolated Dev Stack Runbook (DGX Perf Lab)
+
+This runbook defines how to run an **isolated development stack** for performance testing on DGX without touching production services.
+
+## Scope & Safety
+
+- Uses `docker/docker-compose.dev.yaml` only.
+- Uses separate container names, ports, and volumes from the primary stack.
+- Targets a dedicated dev Postgres database (`atlas-dev-db`, `enso_atlas_dev`).
+- **No schema migrations against production DB are allowed without explicit approval.**
+
+## Files
+
+- Compose file: `docker/docker-compose.dev.yaml`
+- Startup wrapper: `scripts/dev-stack-up.sh`
+- Shutdown wrapper: `scripts/dev-stack-down.sh`
+- Optional env template: `docker/.env.dev.example`
+
+## 1) Prepare host (DGX)
+
+From repo root:
+
+```bash
+cp docker/.env.dev.example docker/.env.dev
+# Edit docker/.env.dev if you need custom paths/credentials/ports
+```
+
+Recommended directories (if using defaults):
+
+```bash
+mkdir -p data-dev outputs-dev .cache/huggingface
+```
+
+## 2) Start isolated dev stack
+
+```bash
+./scripts/dev-stack-up.sh
+```
+
+This starts a compose project named `enso-atlas-dev`.
+
+### Port map (dev stack)
+
+- API health endpoint: `http://localhost:18003/api/health`
+- UI mapping: `17862 -> 7860`
+- Postgres mapping: `15433 -> 5432`
+
+## 3) Health checks
+
+### Basic container status
+
+```bash
+docker compose --project-name enso-atlas-dev -f docker/docker-compose.dev.yaml ps
+```
+
+### API health
+
+```bash
+curl -fsS http://localhost:18003/api/health
+```
+
+### DB readiness
+
+```bash
+docker exec atlas-dev-db pg_isready -U enso_dev -d enso_atlas_dev
+```
+
+## 4) Stop stack
+
+Standard stop (keeps volumes/data):
+
+```bash
+./scripts/dev-stack-down.sh
+```
+
+Stop and remove dev volumes (destructive to dev data only):
+
+```bash
+./scripts/dev-stack-down.sh --purge-volumes
+```
+
+## 5) Rollback / Recovery
+
+If a dev stack update causes issues:
+
+1. Stop dev stack:
+   ```bash
+   ./scripts/dev-stack-down.sh
+   ```
+2. Revert code/compose changes to last known-good commit:
+   ```bash
+   git checkout <known-good-commit> -- docker/docker-compose.dev.yaml scripts/dev-stack-up.sh scripts/dev-stack-down.sh docs/dev-stack-runbook.md docker/.env.dev.example
+   ```
+3. Start again:
+   ```bash
+   ./scripts/dev-stack-up.sh
+   ```
+
+## 6) Guardrails checklist
+
+- [ ] Using `docker/docker-compose.dev.yaml` (not prod compose)
+- [ ] Dev container names (`enso-atlas-dev`, `atlas-dev-db`)
+- [ ] Dev-only ports (`17862`, `18003`, `15433`)
+- [ ] Dev DB URL points to `atlas-dev-db`
+- [ ] No schema migrations against production DB without explicit approval

--- a/scripts/dev-stack-down.sh
+++ b/scripts/dev-stack-down.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker/docker-compose.dev.yaml"
+PROJECT_NAME="enso-atlas-dev"
+DEFAULT_ENV_FILE="$ROOT_DIR/docker/.env.dev"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "Error: $COMPOSE_FILE not found." >&2
+  exit 1
+fi
+
+compose_cmd=(docker compose --project-name "$PROJECT_NAME" -f "$COMPOSE_FILE")
+if [[ -f "$DEFAULT_ENV_FILE" ]]; then
+  compose_cmd+=(--env-file "$DEFAULT_ENV_FILE")
+fi
+
+extra_args=(--remove-orphans)
+if [[ "${1:-}" == "--purge-volumes" ]]; then
+  echo "[dev-stack-down] --purge-volumes enabled: removing dev volumes for $PROJECT_NAME"
+  extra_args+=(--volumes)
+fi
+
+echo "[dev-stack-down] Stopping isolated dev stack: $PROJECT_NAME"
+echo "[dev-stack-down] Safety: this script targets only docker/docker-compose.dev.yaml"
+"${compose_cmd[@]}" down "${extra_args[@]}"

--- a/scripts/dev-stack-up.sh
+++ b/scripts/dev-stack-up.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker/docker-compose.dev.yaml"
+PROJECT_NAME="enso-atlas-dev"
+DEFAULT_ENV_FILE="$ROOT_DIR/docker/.env.dev"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "Error: $COMPOSE_FILE not found." >&2
+  exit 1
+fi
+
+compose_cmd=(docker compose --project-name "$PROJECT_NAME" -f "$COMPOSE_FILE")
+if [[ -f "$DEFAULT_ENV_FILE" ]]; then
+  compose_cmd+=(--env-file "$DEFAULT_ENV_FILE")
+fi
+
+echo "[dev-stack-up] Starting isolated dev stack: $PROJECT_NAME"
+echo "[dev-stack-up] Compose file: $COMPOSE_FILE"
+echo "[dev-stack-up] Safety: no schema migrations against production DB without explicit approval."
+
+"${compose_cmd[@]}" config >/dev/null
+"${compose_cmd[@]}" up -d --build
+"${compose_cmd[@]}" ps
+
+echo
+echo "Dev API expected at: http://localhost:18003/api/health"
+echo "Dev UI port mapping: localhost:17862 -> container:7860"
+echo "Dev Postgres mapping: localhost:15433 -> container:5432"


### PR DESCRIPTION
## Summary
- add an isolated dev compose stack for DGX perf testing (`docker/docker-compose.dev.yaml`)
- add safe up/down wrappers (`scripts/dev-stack-up.sh`, `scripts/dev-stack-down.sh`)
- add dev runbook with startup, health checks, rollback steps (`docs/dev-stack-runbook.md`)
- add optional dev env template (`docker/.env.dev.example`)

## Safety
- keeps production stack untouched (separate project/container names, ports, and volumes)
- explicit guardrail: **no schema migrations against prod DB without approval**

## Validation
- `docker compose --project-name enso-atlas-dev -f docker/docker-compose.dev.yaml --env-file docker/.env.dev.example config`
- `bash -n scripts/dev-stack-up.sh`
- `bash -n scripts/dev-stack-down.sh`

Fixes #101
