### PR TITLE
feat(perf): add backend/frontend observability baseline

### DIFF
--- a/docs/perf-baseline.md
+++ b/docs/perf-baseline.md
@@ -1,0 +1,103 @@
+# Performance Baseline (Dev Observability)
+
+This document defines a **lightweight, toggleable** perf baseline for Enso Atlas.
+It is designed for day-to-day development with minimal runtime risk.
+
+## What was added
+
+### Backend (FastAPI)
+
+- Request timing middleware (enabled by default in dev-style runs):
+  - `method`
+  - normalized `path`
+  - `status`
+  - `duration_ms`
+  - `request_id`
+- Structured log line prefix: `request_timing {...}`
+- In-memory rolling latency tracker with percentile summaries.
+- New endpoint:
+  - `GET /api/perf/latency-summary`
+
+### Frontend (Next.js)
+
+- Client-side perf logger (`frontend/src/lib/perfLogger.ts`) for:
+  - route render timing (`route_render_ms`)
+  - panel switch timing (`panel_render_ms`)
+  - web-vitals-style entries (LCP/FID/CLS/paint when supported)
+- Global observer mounted in layout (`PerfObserver`).
+- Panel timing hooks in main app page for right sidebar and mobile panel switches.
+
+### Tooling
+
+- `scripts/benchmark_dev.sh` for quick local API latency sampling.
+
+---
+
+## Toggles
+
+### Backend env vars
+
+- `ENSO_PERF_ENABLED` (default: `true`)
+  - `0/false` disables middleware tracking.
+- `ENSO_PERF_SUMMARY_ENABLED` (default: same as `ENSO_PERF_ENABLED`)
+  - controls `/api/perf/latency-summary`.
+- `ENSO_PERF_MAX_SAMPLES` (default: `2000`)
+  - in-memory rolling window size.
+- `ENSO_PERF_ROUTE_LIMIT` (default: `25`)
+  - max route rows returned in summary.
+
+### Frontend env vars
+
+- `NEXT_PUBLIC_ENABLE_PERF_LOGS`
+  - `true/1`: force-enable perf console logs
+  - `false/0`: disable perf console logs
+  - unset: enabled in dev, disabled in production
+
+---
+
+## How to run
+
+### 1) Start backend/frontend normally
+
+No schema/database changes are required.
+
+### 2) Generate API baseline samples
+
+```bash
+./scripts/benchmark_dev.sh
+```
+
+Optional:
+
+```bash
+SAMPLES=20 ENSO_API_BASE_URL=http://localhost:8000 ./scripts/benchmark_dev.sh
+```
+
+The script prints per-endpoint `p50/p95/max` and writes raw CSV under `benchmarks/`.
+
+### 3) Read live in-memory summary
+
+```bash
+curl -s http://localhost:8000/api/perf/latency-summary | python3 -m json.tool
+```
+
+### 4) Inspect frontend metrics (dev)
+
+Open browser devtools console and filter for:
+
+- `[enso-perf] route_render_ms`
+- `[enso-perf] panel_render_ms`
+- `[enso-perf] web_vitals_*`
+
+---
+
+## Interpreting the baseline
+
+Use these as initial guardrails (adjust per environment):
+
+- API `p50` stable and low variance across runs.
+- API `p95` highlights tail latency regressions.
+- Panel/route timings should remain consistent after UI changes.
+- Track status mix (`2xx/4xx/5xx`) during benchmarks to avoid false perf conclusions.
+
+For regression checks, compare against a prior CSV and `/api/perf/latency-summary` snapshot from a known-good commit.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,6 @@
 # Local backend:  http://localhost:8000
 # Docker backend: http://localhost:8003
 NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Optional frontend perf console logging (default: enabled in dev, disabled in prod)
+# NEXT_PUBLIC_ENABLE_PERF_LOGS=true

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ToastProvider } from "@/components/ui";
 import { ProjectProvider } from "@/contexts/ProjectContext";
 import { DisclaimerBanner } from "@/components/layout/DisclaimerBanner";
 import { ThemeScript } from "@/components/ThemeScript";
+import { PerfObserver } from "@/components/PerfObserver";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -51,6 +52,7 @@ export default function RootLayout({
           <ProjectProvider>
             <DisclaimerBanner />
             <ErrorBoundary>{children}</ErrorBoundary>
+            <PerfObserver />
           </ProjectProvider>
         </ToastProvider>
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -29,6 +29,7 @@ import type { UserViewMode } from "@/components/layout/Header";
 import { PatchZoomModal, KeyboardShortcutsModal } from "@/components/modals";
 import { useAnalysis } from "@/hooks/useAnalysis";
 import { useKeyboardShortcuts, type KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
+import { usePanelSwitchPerf } from "@/hooks/usePerfInstrumentation";
 import { getDziUrl, getHeatmapUrl, healthCheck, semanticSearch, getSlideQC, getAnnotations, saveAnnotation, deleteAnnotation, getSlides, analyzeSlideMultiModel, embedSlideWithPolling, visualSearch, getSlideCachedResults, getPatchCoords, getProjectAvailableModels, type AvailableModelDetail } from "@/lib/api";
 import { getClientApiBaseUrl } from "@/lib/clientApiBase";
 import { deduplicateSlides } from "@/lib/slideUtils";
@@ -277,6 +278,9 @@ function HomePage() {
   // Desktop sidebar collapse state (left only; right panel is always visible)
   const [leftSidebarOpen, setLeftSidebarOpen] = useState(true);
   const leftPanelRef = useRef<PanelImperativeHandle>(null);
+
+  usePanelSwitchPerf("right-sidebar", activeRightPanel);
+  usePanelSwitchPerf("mobile-panel", mobilePanelTab);
 
   // Check if this is a first visit (show welcome modal)
   useEffect(() => {

--- a/frontend/src/components/PerfObserver.tsx
+++ b/frontend/src/components/PerfObserver.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { logPerfMetric, setupWebVitalsLogging } from "@/lib/perfLogger";
+import { useRoutePerfLogger } from "@/hooks/usePerfInstrumentation";
+
+export function PerfObserver() {
+  const pathname = usePathname() || "/";
+
+  useRoutePerfLogger(pathname);
+
+  useEffect(() => {
+    return setupWebVitalsLogging();
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof performance === "undefined") return;
+
+    const navEntries = performance.getEntriesByType("navigation");
+    const nav = navEntries[0] as PerformanceNavigationTiming | undefined;
+    if (!nav) return;
+
+    logPerfMetric("navigation_ttfb_ms", {
+      value: nav.responseStart,
+      unit: "ms",
+      route: pathname,
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/frontend/src/hooks/usePerfInstrumentation.ts
+++ b/frontend/src/hooks/usePerfInstrumentation.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { measureOnNextPaint } from "@/lib/perfLogger";
+
+export function useRoutePerfLogger(pathname: string): void {
+  const previousRouteRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!pathname || typeof window === "undefined") return;
+
+    const startedAt = performance.now();
+    measureOnNextPaint(
+      "route_render_ms",
+      {
+        route: pathname,
+        from_route: previousRouteRef.current ?? undefined,
+      },
+      startedAt
+    );
+
+    previousRouteRef.current = pathname;
+  }, [pathname]);
+}
+
+export function usePanelSwitchPerf(panelGroup: string, panel: string): void {
+  const previousPanelRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!panel || typeof window === "undefined") return;
+
+    const startedAt = performance.now();
+    measureOnNextPaint(
+      "panel_render_ms",
+      {
+        panel_group: panelGroup,
+        panel,
+        from_panel: previousPanelRef.current ?? undefined,
+        route: window.location.pathname,
+      },
+      startedAt
+    );
+
+    previousPanelRef.current = panel;
+  }, [panelGroup, panel]);
+}

--- a/frontend/src/lib/perfLogger.ts
+++ b/frontend/src/lib/perfLogger.ts
@@ -1,0 +1,126 @@
+export interface PerfLogPayload {
+  value: number;
+  unit?: string;
+  route?: string;
+  panel?: string;
+  panel_group?: string;
+  from_panel?: string;
+  from_route?: string;
+  [key: string]: unknown;
+}
+
+const PERF_FLAG = process.env.NEXT_PUBLIC_ENABLE_PERF_LOGS;
+
+export function isPerfLoggingEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+
+  if (PERF_FLAG != null) {
+    return ["1", "true", "yes", "on"].includes(PERF_FLAG.toLowerCase());
+  }
+
+  // Default: enabled in development, off in production.
+  return process.env.NODE_ENV !== "production";
+}
+
+export function logPerfMetric(name: string, payload: PerfLogPayload): void {
+  if (!isPerfLoggingEnabled()) return;
+
+  const ts = new Date().toISOString();
+  // Structured console output (copy/paste friendly for analysis scripts).
+  console.info("[enso-perf]", {
+    metric: name,
+    ts,
+    ...payload,
+  });
+}
+
+export function measureOnNextPaint(
+  metric: string,
+  payload: Omit<PerfLogPayload, "value" | "unit">,
+  startedAtMs: number = performance.now()
+): void {
+  if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+    return;
+  }
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      const durationMs = performance.now() - startedAtMs;
+      logPerfMetric(metric, {
+        ...payload,
+        value: durationMs,
+        unit: "ms",
+      });
+    });
+  });
+}
+
+export function setupWebVitalsLogging(): () => void {
+  if (
+    typeof window === "undefined" ||
+    typeof PerformanceObserver === "undefined" ||
+    !isPerfLoggingEnabled()
+  ) {
+    return () => {};
+  }
+
+  const observers: PerformanceObserver[] = [];
+
+  const setups: Array<{ type: string; metric: string; value: (entry: PerformanceEntry) => number }> = [
+    {
+      type: "largest-contentful-paint",
+      metric: "web_vitals_lcp_ms",
+      value: (entry) => entry.startTime,
+    },
+    {
+      type: "first-input",
+      metric: "web_vitals_fid_ms",
+      value: (entry) => {
+        const fidEntry = entry as PerformanceEntry & { processingStart?: number };
+        if (typeof fidEntry.processingStart !== "number") return 0;
+        return fidEntry.processingStart - fidEntry.startTime;
+      },
+    },
+    {
+      type: "layout-shift",
+      metric: "web_vitals_cls",
+      value: (entry) => {
+        const clsEntry = entry as PerformanceEntry & { hadRecentInput?: boolean; value?: number };
+        if (clsEntry.hadRecentInput) return 0;
+        return typeof clsEntry.value === "number" ? clsEntry.value : 0;
+      },
+    },
+    {
+      type: "paint",
+      metric: "web_vitals_paint_ms",
+      value: (entry) => entry.startTime,
+    },
+  ];
+
+  for (const setup of setups) {
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          const value = setup.value(entry);
+          if (!Number.isFinite(value) || value <= 0) continue;
+
+          logPerfMetric(setup.metric, {
+            value,
+            unit: setup.metric.includes("_ms") ? "ms" : undefined,
+            entry_type: setup.type,
+            name: entry.name,
+          });
+        }
+      });
+
+      observer.observe({ type: setup.type, buffered: true });
+      observers.push(observer);
+    } catch {
+      // Some entry types are browser/version specific.
+    }
+  }
+
+  return () => {
+    observers.forEach((observer) => observer.disconnect());
+  };
+}

--- a/scripts/benchmark_dev.sh
+++ b/scripts/benchmark_dev.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Lightweight dev API latency benchmark for Enso Atlas.
+
+set -euo pipefail
+
+BASE_URL="${1:-${ENSO_API_BASE_URL:-http://localhost:8000}}"
+SAMPLES="${SAMPLES:-10}"
+OUT_DIR="${OUT_DIR:-benchmarks}"
+
+if ! [[ "$SAMPLES" =~ ^[0-9]+$ ]] || [ "$SAMPLES" -lt 1 ]; then
+  echo "SAMPLES must be a positive integer (got: $SAMPLES)" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+RAW_CSV="$OUT_DIR/dev-latency-${STAMP}.csv"
+
+ENDPOINTS=(
+  "/api/health"
+  "/health"
+  "/api/slides"
+  "/api/tags"
+  "/api/projects"
+)
+
+printf "endpoint,sample,http_code,total_ms\n" > "$RAW_CSV"
+
+echo "Benchmarking $BASE_URL (${SAMPLES} samples/endpoint)"
+
+for endpoint in "${ENDPOINTS[@]}"; do
+  echo "→ $endpoint"
+  for ((i = 1; i <= SAMPLES; i++)); do
+    line="$(curl -sS -o /dev/null -w "%{time_total} %{http_code}" "${BASE_URL}${endpoint}" || echo "nan 000")"
+    total_s="${line%% *}"
+    code="${line##* }"
+
+    total_ms="$(python3 - <<PY
+import math
+v = float("$total_s") if "$total_s" != "nan" else float('nan')
+print("nan" if math.isnan(v) else f"{v * 1000.0:.3f}")
+PY
+)"
+
+    printf "%s,%s,%s,%s\n" "$endpoint" "$i" "$code" "$total_ms" >> "$RAW_CSV"
+  done
+done
+
+python3 - "$RAW_CSV" <<'PY'
+import csv
+import math
+import statistics
+import sys
+from collections import defaultdict
+
+csv_path = sys.argv[1]
+rows = defaultdict(list)
+status_counts = defaultdict(lambda: defaultdict(int))
+
+with open(csv_path, newline="", encoding="utf-8") as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        endpoint = row["endpoint"]
+        status = row["http_code"]
+        status_counts[endpoint][status] += 1
+        try:
+            v = float(row["total_ms"])
+        except Exception:
+            continue
+        if math.isnan(v):
+            continue
+        rows[endpoint].append(v)
+
+
+def percentile(values, p):
+    if not values:
+        return 0.0
+    arr = sorted(values)
+    if len(arr) == 1:
+        return arr[0]
+    idx = (len(arr) - 1) * (p / 100.0)
+    lo = int(idx)
+    hi = min(lo + 1, len(arr) - 1)
+    if lo == hi:
+        return arr[lo]
+    frac = idx - lo
+    return arr[lo] + (arr[hi] - arr[lo]) * frac
+
+print("\nLatency summary (ms):")
+print(f"{'Endpoint':34} {'n':>4} {'p50':>10} {'p95':>10} {'max':>10} {'status':>18}")
+print("-" * 92)
+
+for endpoint, vals in rows.items():
+    status = ",".join(f"{k}:{v}" for k, v in sorted(status_counts[endpoint].items()))
+    print(
+        f"{endpoint:34} {len(vals):4d} {percentile(vals,50):10.2f} "
+        f"{percentile(vals,95):10.2f} {max(vals):10.2f} {status:>18}"
+    )
+
+print("\nRaw samples:", csv_path)
+PY
+

--- a/src/enso_atlas/api/main.py
+++ b/src/enso_atlas/api/main.py
@@ -16,6 +16,7 @@ import base64
 import io
 import time
 import hashlib
+import uuid
 from datetime import datetime
 from .embedding_tasks import task_manager, TaskStatus, EmbeddingTask
 from .report_tasks import report_task_manager, ReportTaskStatus, ReportTask
@@ -31,6 +32,7 @@ from .model_scope import (
 )
 from .heatmap_grid import compute_heatmap_grid_coverage
 from collections import deque
+from .perf_observability import InMemoryLatencyTracker, RequestLatencyRecord, normalize_perf_path, should_track_path
 
 import numpy as np
 from PIL import Image
@@ -924,6 +926,95 @@ def create_app(
     _data_root: Path = Path("data")
     slides_dir: Path = _data_root / "slides"
 
+    def _env_flag(name: str, default: bool) -> bool:
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+    def _env_int(name: str, default: int, minimum: int = 1) -> int:
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            return max(minimum, int(raw))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid integer for %s=%r; using default=%d",
+                name,
+                raw,
+                default,
+            )
+            return default
+
+    perf_enabled = _env_flag("ENSO_PERF_ENABLED", default=True)
+    perf_summary_enabled = _env_flag("ENSO_PERF_SUMMARY_ENABLED", default=perf_enabled)
+    perf_max_samples = _env_int("ENSO_PERF_MAX_SAMPLES", default=2000, minimum=100)
+    perf_route_limit = _env_int("ENSO_PERF_ROUTE_LIMIT", default=25, minimum=1)
+    perf_tracker = InMemoryLatencyTracker(max_samples=perf_max_samples)
+    perf_logger = logging.getLogger("enso_atlas.perf")
+
+    if perf_enabled:
+
+        @app.middleware("http")
+        async def request_timing_middleware(request: Request, call_next):
+            request_id = request.headers.get("x-request-id") or uuid.uuid4().hex[:12]
+            request.state.request_id = request_id
+            started_at = time.perf_counter()
+
+            response = None
+            status_code = 500
+
+            try:
+                response = await call_next(request)
+                status_code = response.status_code
+            except Exception:
+                status_code = 500
+                raise
+            finally:
+                route_obj = request.scope.get("route")
+                route_path = getattr(route_obj, "path", None) or request.url.path
+                normalized_path = normalize_perf_path(route_path)
+                duration_ms = (time.perf_counter() - started_at) * 1000.0
+
+                if should_track_path(normalized_path):
+                    perf_tracker.add(
+                        RequestLatencyRecord(
+                            method=request.method.upper(),
+                            path=normalized_path,
+                            status=status_code,
+                            duration_ms=duration_ms,
+                            request_id=request_id,
+                            ts_unix=time.time(),
+                        )
+                    )
+                    perf_logger.info(
+                        "request_timing %s",
+                        json.dumps(
+                            {
+                                "method": request.method.upper(),
+                                "path": normalized_path,
+                                "status": status_code,
+                                "duration_ms": round(duration_ms, 3),
+                                "request_id": request_id,
+                            },
+                            separators=(",", ":"),
+                        ),
+                    )
+
+            if response is not None:
+                response.headers.setdefault("X-Request-ID", request_id)
+                return response
+
+            raise RuntimeError("request_timing_middleware reached unexpected state")
+
+    logger.info(
+        "Perf observability enabled=%s summary_enabled=%s max_samples=%d",
+        perf_enabled,
+        perf_summary_enabled,
+        perf_max_samples,
+    )
+
     def _classifier_threshold(default: float = 0.5) -> float:
         """Return a safe numeric decision threshold for binary predictions."""
         raw_threshold = getattr(classifier, "threshold", None)
@@ -1725,6 +1816,30 @@ def create_app(
     async def api_health_check():
         """Health check endpoint (aliased for frontend compatibility)."""
         return await health_check()
+
+    @app.get("/api/perf/latency-summary")
+    async def perf_latency_summary():
+        """Return rolling p50/p95 latency stats from in-memory request timings."""
+        if not perf_enabled:
+            return {
+                "enabled": False,
+                "summary_enabled": False,
+                "reason": "Set ENSO_PERF_ENABLED=1 to collect request timings.",
+            }
+
+        if not perf_summary_enabled:
+            raise HTTPException(
+                status_code=404,
+                detail="Perf latency summary endpoint disabled. Set ENSO_PERF_SUMMARY_ENABLED=1.",
+            )
+
+        return {
+            "enabled": True,
+            "summary_enabled": True,
+            "max_samples": perf_max_samples,
+            "route_limit": perf_route_limit,
+            "summary": perf_tracker.summary(limit_routes=perf_route_limit),
+        }
 
     @app.get("/")
     async def root():

--- a/src/enso_atlas/api/perf_observability.py
+++ b/src/enso_atlas/api/perf_observability.py
@@ -1,0 +1,138 @@
+"""Lightweight request/route observability primitives for dev perf baselines."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+import threading
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class RequestLatencyRecord:
+    """Single request timing sample."""
+
+    method: str
+    path: str
+    status: int
+    duration_ms: float
+    request_id: str
+    ts_unix: float
+
+
+def percentile(values: Iterable[float], p: float) -> float:
+    """Compute percentile using linear interpolation (numpy-like)."""
+    arr = sorted(float(v) for v in values)
+    if not arr:
+        return 0.0
+    if len(arr) == 1:
+        return float(arr[0])
+
+    p = max(0.0, min(100.0, float(p)))
+    rank = (len(arr) - 1) * (p / 100.0)
+    lo = int(rank)
+    hi = min(lo + 1, len(arr) - 1)
+    if lo == hi:
+        return float(arr[lo])
+
+    frac = rank - lo
+    return float(arr[lo] + (arr[hi] - arr[lo]) * frac)
+
+
+class InMemoryLatencyTracker:
+    """Thread-safe rolling latency tracker.
+
+    Keeps an in-memory ring buffer of recent request timings and computes
+    p50/p95 summaries overall and per route signature ("METHOD path").
+    """
+
+    def __init__(self, max_samples: int = 2000):
+        self.max_samples = max(100, int(max_samples))
+        self._samples: deque[RequestLatencyRecord] = deque(maxlen=self.max_samples)
+        self._lock = threading.Lock()
+
+    def add(self, sample: RequestLatencyRecord) -> None:
+        with self._lock:
+            self._samples.append(sample)
+
+    def size(self) -> int:
+        with self._lock:
+            return len(self._samples)
+
+    def summary(self, limit_routes: int = 25) -> dict[str, Any]:
+        with self._lock:
+            items = list(self._samples)
+
+        durations = [s.duration_ms for s in items]
+        summary = {
+            "window_samples": len(items),
+            "p50_ms": round(percentile(durations, 50), 3),
+            "p95_ms": round(percentile(durations, 95), 3),
+            "max_ms": round(max(durations), 3) if durations else 0.0,
+            "routes": [],
+        }
+
+        by_route: dict[str, list[float]] = {}
+        statuses: dict[str, dict[int, int]] = {}
+
+        for item in items:
+            route_key = f"{item.method} {item.path}"
+            by_route.setdefault(route_key, []).append(item.duration_ms)
+            route_statuses = statuses.setdefault(route_key, {})
+            route_statuses[item.status] = route_statuses.get(item.status, 0) + 1
+
+        ranked = sorted(
+            by_route.items(),
+            key=lambda kv: (percentile(kv[1], 95), len(kv[1])),
+            reverse=True,
+        )
+
+        for route_key, vals in ranked[: max(1, int(limit_routes))]:
+            summary["routes"].append(
+                {
+                    "route": route_key,
+                    "count": len(vals),
+                    "p50_ms": round(percentile(vals, 50), 3),
+                    "p95_ms": round(percentile(vals, 95), 3),
+                    "max_ms": round(max(vals), 3),
+                    "status_counts": statuses.get(route_key, {}),
+                }
+            )
+
+        return summary
+
+
+def normalize_perf_path(path: str) -> str:
+    """Normalize path to reduce high-cardinality in perf summaries."""
+    path = (path or "/").strip() or "/"
+    if "?" in path:
+        path = path.split("?", 1)[0]
+
+    parts = []
+    for part in path.split("/"):
+        if not part:
+            continue
+        if len(part) >= 8 and all(c in "0123456789abcdefABCDEF-" for c in part):
+            parts.append(":id")
+            continue
+        if part.isdigit():
+            parts.append(":id")
+            continue
+        parts.append(part)
+
+    return "/" + "/".join(parts)
+
+
+def should_track_path(path: str) -> bool:
+    """Exclude noisy/non-business routes from perf tracking."""
+    normalized = normalize_perf_path(path)
+    excluded = {
+        "/api/perf/latency-summary",
+        "/health",
+        "/api/health",
+        "/api/docs",
+        "/api/redoc",
+        "/docs",
+        "/redoc",
+    }
+    return normalized not in excluded

--- a/tests/test_perf_observability_backend.py
+++ b/tests/test_perf_observability_backend.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PERF_PATH = REPO_ROOT / "src" / "enso_atlas" / "api" / "perf_observability.py"
+
+_spec = importlib.util.spec_from_file_location("perf_observability", PERF_PATH)
+assert _spec and _spec.loader
+_perf = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _perf
+_spec.loader.exec_module(_perf)  # type: ignore[attr-defined]
+
+
+InMemoryLatencyTracker = _perf.InMemoryLatencyTracker
+RequestLatencyRecord = _perf.RequestLatencyRecord
+normalize_perf_path = _perf.normalize_perf_path
+percentile = _perf.percentile
+should_track_path = _perf.should_track_path
+
+
+def test_percentile_linear_interpolation_matches_expected_values():
+    vals = [10, 20, 30, 40, 50]
+    assert percentile(vals, 50) == 30
+    assert percentile(vals, 95) == 48
+    assert percentile(vals, 0) == 10
+    assert percentile(vals, 100) == 50
+
+
+def test_latency_tracker_summary_contains_overall_and_route_stats():
+    tracker = InMemoryLatencyTracker(max_samples=10)
+
+    for ms in [10, 20, 30]:
+        tracker.add(
+            RequestLatencyRecord(
+                method="GET",
+                path="/api/slides",
+                status=200,
+                duration_ms=ms,
+                request_id=f"req-{ms}",
+                ts_unix=1.0,
+            )
+        )
+
+    for ms in [100, 120]:
+        tracker.add(
+            RequestLatencyRecord(
+                method="POST",
+                path="/api/analyze",
+                status=200,
+                duration_ms=ms,
+                request_id=f"req-{ms}",
+                ts_unix=2.0,
+            )
+        )
+
+    summary = tracker.summary(limit_routes=5)
+
+    assert summary["window_samples"] == 5
+    assert summary["p50_ms"] == 30.0
+    assert summary["p95_ms"] == 116.0
+    assert len(summary["routes"]) >= 2
+
+    slowest = summary["routes"][0]
+    assert slowest["route"] == "POST /api/analyze"
+    assert slowest["p95_ms"] >= 100.0
+
+
+def test_path_normalization_and_exclusions_for_perf_tracking():
+    assert normalize_perf_path("/api/slides/12345") == "/api/slides/:id"
+    assert normalize_perf_path("/api/slides/abcdefff-aaaa-bbbb-cccc-ddddeeeeffff") == "/api/slides/:id"
+
+    assert should_track_path("/api/slides/12345")
+    assert not should_track_path("/api/health")
+    assert not should_track_path("/api/perf/latency-summary")
+
+
+def test_main_api_wires_perf_middleware_and_summary_endpoint():
+    main_src = (REPO_ROOT / "src" / "enso_atlas" / "api" / "main.py").read_text(encoding="utf-8")
+    assert "@app.middleware(\"http\")" in main_src
+    assert "request_timing_middleware" in main_src
+    assert "/api/perf/latency-summary" in main_src
+    assert "X-Request-ID" in main_src

--- a/tests/test_perf_observability_frontend.py
+++ b/tests/test_perf_observability_frontend.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def test_root_layout_mounts_perf_observer():
+    src = _read("frontend/src/app/layout.tsx")
+    assert "PerfObserver" in src
+    assert "<PerfObserver />" in src
+
+
+def test_home_page_logs_panel_switch_timings():
+    src = _read("frontend/src/app/page.tsx")
+    assert "usePanelSwitchPerf" in src
+    assert 'usePanelSwitchPerf("right-sidebar", activeRightPanel)' in src
+    assert 'usePanelSwitchPerf("mobile-panel", mobilePanelTab)' in src
+
+
+def test_perf_logger_supports_toggleable_client_logging():
+    src = _read("frontend/src/lib/perfLogger.ts")
+    assert "NEXT_PUBLIC_ENABLE_PERF_LOGS" in src
+    assert "route_render_ms" not in src  # route metric names belong in hook/component callers
+    assert "[enso-perf]" in src
+
+
+def test_perf_hooks_emit_route_and_panel_metrics():
+    src = _read("frontend/src/hooks/usePerfInstrumentation.ts")
+    assert '"route_render_ms"' in src
+    assert '"panel_render_ms"' in src


### PR DESCRIPTION
## Summary
- add FastAPI request timing middleware with structured logs (`method`, `path`, `status`, `duration_ms`, `request_id`)
- add lightweight in-memory latency tracker + `/api/perf/latency-summary` endpoint (toggleable via env vars)
- add frontend perf observer/hooks for route render and panel switch timing plus web-vitals logging (dev-friendly/toggleable)
- add `scripts/benchmark_dev.sh` for repeatable local latency sampling (`p50/p95/max`)
- add `docs/perf-baseline.md` runbook + interpretation guidance
- add backend/frontend perf observability tests

## Validation
- `pytest -q tests/test_perf_observability_backend.py tests/test_perf_observability_frontend.py`
- `python3 -m py_compile src/enso_atlas/api/perf_observability.py src/enso_atlas/api/main.py`

Fixes #102
