### PR TITLE
perf(slides): virtualize list and debounce filters

### DIFF
--- a/frontend/src/app/slides/page.tsx
+++ b/frontend/src/app/slides/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
@@ -117,6 +117,33 @@ function Pagination({
   );
 }
 
+
+const FILTER_DEBOUNCE_MS = 250;
+
+type SlidesPayload = {
+  slides: (SlideInfo & Partial<ExtendedSlideInfo>)[];
+  total: number;
+};
+
+function hasActiveFilters(filters: SlideFilters): boolean {
+  return Boolean(
+    filters.search ||
+      filters.tags?.length ||
+      filters.groupId ||
+      filters.label ||
+      filters.hasEmbeddings !== undefined ||
+      filters.minPatches !== undefined ||
+      filters.maxPatches !== undefined ||
+      filters.starred ||
+      filters.dateFrom ||
+      filters.dateTo
+  );
+}
+
+function getSlidesCacheKey(filters: SlideFilters, projectId: string): string {
+  return `${projectId}:${JSON.stringify(filters)}`;
+}
+
 export default function SlidesPage() {
   const router = useRouter();
   const { showToast } = useToast();
@@ -144,6 +171,17 @@ export default function SlidesPage() {
     sortBy: "date",
     sortOrder: "desc",
   });
+  const [queryFilters, setQueryFilters] = useState<SlideFilters>({
+    page: 1,
+    perPage: 20,
+    sortBy: "date",
+    sortOrder: "desc",
+  });
+
+  const filterDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const slidesCacheRef = useRef<Map<string, SlidesPayload>>(new Map());
+  const inFlightRequestRef = useRef<Map<string, Promise<SlidesPayload>>>(new Map());
+  const latestRequestRef = useRef(0);
 
   // Selection state
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -199,46 +237,107 @@ export default function SlidesPage() {
     fetchMetadata();
   }, []);
 
-  // Fetch slides when filters change
-  const fetchSlides = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      // Use searchSlides if we have any filters, otherwise use getSlides
-      const hasFilters =
-        filters.search ||
-        filters.tags?.length ||
-        filters.groupId ||
-        filters.label ||
-        filters.hasEmbeddings !== undefined ||
-        filters.minPatches !== undefined ||
-        filters.maxPatches !== undefined ||
-        filters.starred ||
-        filters.dateFrom ||
-        filters.dateTo;
+  useEffect(() => {
+    return () => {
+      if (filterDebounceRef.current) {
+        clearTimeout(filterDebounceRef.current);
+      }
+    };
+  }, []);
 
-      if (hasFilters) {
-        const result = await searchSlides(filters, currentProject.id);
-        setSlides(result.slides);
-        setTotalSlides(result.total);
+  const commitQueryFilters = useCallback((nextFilters: SlideFilters, debounce = false) => {
+    if (filterDebounceRef.current) {
+      clearTimeout(filterDebounceRef.current);
+      filterDebounceRef.current = null;
+    }
+
+    if (debounce) {
+      filterDebounceRef.current = setTimeout(() => {
+        setQueryFilters(nextFilters);
+      }, FILTER_DEBOUNCE_MS);
+      return;
+    }
+
+    setQueryFilters(nextFilters);
+  }, []);
+
+  // Fetch slides when filters change
+  const fetchSlides = useCallback(
+    async ({ forceNetwork = false }: { forceNetwork?: boolean } = {}) => {
+      const activeFilters = queryFilters;
+      const cacheKey = getSlidesCacheKey(activeFilters, currentProject.id);
+      const cached = forceNetwork ? undefined : slidesCacheRef.current.get(cacheKey);
+
+      if (cached) {
+        setSlides(cached.slides);
+        setTotalSlides(cached.total);
+        setIsLoading(false);
       } else {
+        setIsLoading(true);
+      }
+
+      const requestId = ++latestRequestRef.current;
+
+      const executeRequest = async (): Promise<SlidesPayload> => {
+        if (hasActiveFilters(activeFilters)) {
+          const result = await searchSlides(activeFilters, currentProject.id);
+          return {
+            slides: result.slides,
+            total: result.total,
+          };
+        }
+
         const result = await getSlides({
-          page: filters.page,
-          perPage: filters.perPage,
+          page: activeFilters.page,
+          perPage: activeFilters.perPage,
           projectId: currentProject.id,
         });
-        setSlides(result.slides);
-        setTotalSlides(result.total);
+        return {
+          slides: result.slides,
+          total: result.total,
+        };
+      };
+
+      let requestPromise: Promise<SlidesPayload>;
+      if (forceNetwork) {
+        requestPromise = executeRequest();
+      } else {
+        const inFlightRequest = inFlightRequestRef.current.get(cacheKey);
+        if (inFlightRequest) {
+          requestPromise = inFlightRequest;
+        } else {
+          requestPromise = executeRequest();
+          inFlightRequestRef.current.set(cacheKey, requestPromise);
+        }
       }
-    } catch (error) {
-      console.error("Failed to fetch slides:", error);
-      showToast({
-        type: "error",
-        message: "Failed to load slides. Please try again.",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  }, [filters, showToast, currentProject.id]);
+
+      try {
+        const result = await requestPromise;
+        slidesCacheRef.current.set(cacheKey, result);
+
+        if (latestRequestRef.current === requestId) {
+          setSlides(result.slides);
+          setTotalSlides(result.total);
+        }
+      } catch (error) {
+        if (latestRequestRef.current === requestId) {
+          console.error("Failed to fetch slides:", error);
+          showToast({
+            type: "error",
+            message: "Failed to load slides. Please try again.",
+          });
+        }
+      } finally {
+        if (!forceNetwork) {
+          inFlightRequestRef.current.delete(cacheKey);
+        }
+        if (latestRequestRef.current === requestId) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [queryFilters, showToast, currentProject.id]
+  );
 
   useEffect(() => {
     fetchSlides();
@@ -247,21 +346,29 @@ export default function SlidesPage() {
   // Reset selection and pagination when switching projects.
   useEffect(() => {
     setSelectedIds(new Set());
-    setFilters((prev) => ({ ...prev, page: 1 }));
-  }, [currentProject.id]);
+    setFilters((prev) => {
+      const next = { ...prev, page: 1 };
+      commitQueryFilters(next, false);
+      return next;
+    });
+  }, [currentProject.id, commitQueryFilters]);
 
   // Handlers
   const handleRefresh = async () => {
     setIsRefreshing(true);
-    await fetchSlides();
+    await fetchSlides({ forceNetwork: true });
     setIsRefreshing(false);
     showToast({ type: "success", message: "Slides refreshed" });
   };
 
-  const handleFiltersChange = useCallback((newFilters: SlideFilters) => {
-    setFilters(newFilters);
-    setSelectedIds(new Set());
-  }, []);
+  const handleFiltersChange = useCallback(
+    (newFilters: SlideFilters) => {
+      setFilters(newFilters);
+      commitQueryFilters(newFilters, true);
+      setSelectedIds(new Set());
+    },
+    [commitQueryFilters]
+  );
 
   const handleSelectSlide = useCallback((id: string, selected: boolean) => {
     setSelectedIds((prev) => {
@@ -332,20 +439,32 @@ export default function SlidesPage() {
 
   const handleSort = useCallback(
     (field: string) => {
-      setFilters((prev) => ({
-        ...prev,
-        sortBy: field,
-        sortOrder: prev.sortBy === field && prev.sortOrder === "asc" ? "desc" : "asc",
-        page: 1,
-      }));
+      setFilters((prev) => {
+        const next: SlideFilters = {
+          ...prev,
+          sortBy: field,
+          sortOrder: prev.sortBy === field && prev.sortOrder === "asc" ? "desc" : "asc",
+          page: 1,
+        };
+        commitQueryFilters(next, false);
+        return next;
+      });
+      setSelectedIds(new Set());
     },
-    []
+    [commitQueryFilters]
   );
 
-  const handlePageChange = useCallback((page: number) => {
-    setFilters((prev) => ({ ...prev, page }));
-    setSelectedIds(new Set());
-  }, []);
+  const handlePageChange = useCallback(
+    (page: number) => {
+      setFilters((prev) => {
+        const next = { ...prev, page };
+        commitQueryFilters(next, false);
+        return next;
+      });
+      setSelectedIds(new Set());
+    },
+    [commitQueryFilters]
+  );
 
   // Bulk action handlers
   const handleBulkAddTags = useCallback(
@@ -358,7 +477,7 @@ export default function SlidesPage() {
           type: "success",
           message: `Added ${tagNames.length} tag(s) to ${selectedIds.size} slide(s)`,
         });
-        fetchSlides();
+        fetchSlides({ forceNetwork: true });
         // Refresh tags
         const newTags = await getAllTags();
         setTags(newTags);
@@ -587,7 +706,7 @@ export default function SlidesPage() {
         {/* Slides content */}
         <div className="flex-1 flex flex-col overflow-hidden">
           {/* Slides view */}
-          <div className="flex-1 overflow-y-auto p-4">
+          <div className="flex-1 min-h-0 p-4">
             {viewMode === "grid" ? (
               <SlideGrid
                 slides={slides}
@@ -602,7 +721,7 @@ export default function SlidesPage() {
                 isLoading={isLoading && slides.length === 0}
               />
             ) : (
-              <div className="bg-white dark:bg-navy-800 rounded-xl shadow-sm border border-gray-200 dark:border-navy-700 overflow-hidden">
+              <div className="bg-white dark:bg-navy-800 rounded-xl shadow-sm border border-gray-200 dark:border-navy-700 overflow-hidden h-full">
                 <SlideTable
                   slides={slides}
                   selectedIds={selectedIds}

--- a/frontend/src/components/slides/SlideGrid.tsx
+++ b/frontend/src/components/slides/SlideGrid.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { Card, CardContent } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
-import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { cn, truncateText } from "@/lib/utils";
 import { getThumbnailUrl } from "@/lib/api";
@@ -20,6 +19,7 @@ import {
   CheckCircle2,
   Circle,
 } from "lucide-react";
+import { getGridColumnCount, getVirtualWindow } from "./virtualization";
 
 interface SlideGridProps {
   slides: (SlideInfo & Partial<ExtendedSlideInfo>)[];
@@ -33,6 +33,11 @@ interface SlideGridProps {
   onDeleteSlide: (id: string) => void;
   isLoading?: boolean;
 }
+
+const CARD_HEIGHT = 320;
+const GRID_GAP = 16;
+const ROW_HEIGHT = CARD_HEIGHT + GRID_GAP;
+const VIRTUALIZE_THRESHOLD = 40;
 
 // Tag colors
 const TAG_COLORS: Record<string, string> = {
@@ -50,7 +55,7 @@ const TAG_COLORS: Record<string, string> = {
 
 function SlideCardSkeleton() {
   return (
-    <Card className="overflow-hidden">
+    <Card className="overflow-hidden h-full">
       <div className="aspect-[4/3] bg-gray-100">
         <Skeleton className="w-full h-full" />
       </div>
@@ -93,14 +98,14 @@ function SlideCard({
   const [imageError, setImageError] = React.useState(false);
   const [isImageLoaded, setIsImageLoaded] = React.useState(false);
   const menuRef = React.useRef<HTMLDivElement>(null);
-  
+
   // Get display labels from project context
-  const positiveLabel = currentProject.positive_class 
+  const positiveLabel = currentProject.positive_class
     ? currentProject.positive_class.charAt(0).toUpperCase() + currentProject.positive_class.slice(1)
     : "Positive";
-  const negativeLabel = currentProject.classes?.find(c => c !== currentProject.positive_class)
-    ? (currentProject.classes.find(c => c !== currentProject.positive_class) as string).charAt(0).toUpperCase() + 
-      (currentProject.classes.find(c => c !== currentProject.positive_class) as string).slice(1)
+  const negativeLabel = currentProject.classes?.find((c) => c !== currentProject.positive_class)
+    ? (currentProject.classes.find((c) => c !== currentProject.positive_class) as string).charAt(0).toUpperCase() +
+      (currentProject.classes.find((c) => c !== currentProject.positive_class) as string).slice(1)
     : "Negative";
 
   // Close menu when clicking outside
@@ -124,7 +129,7 @@ function SlideCard({
   return (
     <Card
       className={cn(
-        "overflow-hidden transition-all duration-200 group cursor-pointer",
+        "overflow-hidden transition-all duration-200 group cursor-pointer h-full flex flex-col",
         isSelected && "ring-2 ring-clinical-500 shadow-lg"
       )}
     >
@@ -145,7 +150,9 @@ function SlideCard({
               const retried = img.dataset.retried;
               if (!retried) {
                 img.dataset.retried = "1";
-                setTimeout(() => { img.src = thumbnailUrl + "?retry=1"; }, 3000);
+                setTimeout(() => {
+                  img.src = thumbnailUrl + "?retry=1";
+                }, 3000);
               } else {
                 setImageError(true);
                 setIsImageLoaded(true);
@@ -225,7 +232,7 @@ function SlideCard({
       </div>
 
       {/* Content */}
-      <CardContent className="p-3" onClick={onView}>
+      <CardContent className="p-3 flex-1 flex flex-col" onClick={onView}>
         {/* Slide name */}
         <h3 className="font-medium text-sm text-gray-900 dark:text-gray-100 truncate mb-1.5" title={slide.filename}>
           {truncateText(slide.id, 30)}
@@ -233,7 +240,7 @@ function SlideCard({
 
         {/* Tags */}
         {slide.tags && slide.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-2">
+          <div className="flex flex-wrap gap-1 mb-2 min-h-[22px]">
             {slide.tags.slice(0, 3).map((tag, idx) => (
               <span
                 key={tag}
@@ -254,7 +261,7 @@ function SlideCard({
         )}
 
         {/* Footer */}
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between mt-auto">
           <div className="flex items-center gap-2 text-xs text-gray-500">
             {slide.numPatches !== undefined && (
               <span className="flex items-center gap-1">
@@ -336,7 +343,7 @@ export function SlideGrid({
   slides,
   selectedIds,
   onSelectSlide,
-  onSelectAll,
+  onSelectAll: _onSelectAll,
   onStarSlide,
   onViewSlide,
   onAnalyzeSlide,
@@ -344,19 +351,76 @@ export function SlideGrid({
   onDeleteSlide,
   isLoading,
 }: SlideGridProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = React.useState(0);
+  const [viewportHeight, setViewportHeight] = React.useState(640);
+  const [containerWidth, setContainerWidth] = React.useState(0);
+  const shouldVirtualize = slides.length >= VIRTUALIZE_THRESHOLD;
+
+  void _onSelectAll;
+
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const updateViewport = () => {
+      setScrollTop(el.scrollTop);
+      setViewportHeight(Math.max(320, el.clientHeight || 0));
+      setContainerWidth(el.clientWidth || 0);
+    };
+
+    updateViewport();
+    el.addEventListener("scroll", updateViewport, { passive: true });
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(updateViewport) : null;
+    resizeObserver?.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", updateViewport);
+      resizeObserver?.disconnect();
+    };
+  }, []);
+
+  const columns = getGridColumnCount(containerWidth);
+  const totalRows = Math.ceil(slides.length / columns);
+
+  const rowWindow = shouldVirtualize
+    ? getVirtualWindow({
+        itemCount: totalRows,
+        itemHeight: ROW_HEIGHT,
+        viewportHeight,
+        scrollTop,
+        overscan: 4,
+      })
+    : {
+        startIndex: 0,
+        endIndex: totalRows,
+        topSpacerHeight: 0,
+        bottomSpacerHeight: 0,
+      };
+
+  const visibleStartIndex = rowWindow.startIndex * columns;
+  const visibleEndIndex = Math.min(slides.length, rowWindow.endIndex * columns);
+  const visibleSlides = slides.slice(visibleStartIndex, visibleEndIndex);
+
   if (isLoading && slides.length === 0) {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
-        {Array.from({ length: 12 }).map((_, i) => (
-          <SlideCardSkeleton key={i} />
-        ))}
+      <div className="h-full overflow-y-auto">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div key={i} className="h-[320px]">
+              <SlideCardSkeleton />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }
 
   if (slides.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="h-full flex flex-col items-center justify-center py-16 text-center">
         <Microscope className="h-16 w-16 text-gray-300 dark:text-gray-600 mb-4" />
         <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No slides found</h3>
         <p className="text-sm text-gray-500 dark:text-gray-400 max-w-sm">
@@ -367,20 +431,31 @@ export function SlideGrid({
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
-      {slides.map((slide) => (
-        <SlideCard
-          key={slide.id}
-          slide={slide}
-          isSelected={selectedIds.has(slide.id)}
-          onSelect={(selected) => onSelectSlide(slide.id, selected)}
-          onStar={() => onStarSlide(slide.id)}
-          onView={() => onViewSlide(slide.id)}
-          onAnalyze={() => onAnalyzeSlide(slide.id)}
-          onAddToGroup={() => onAddToGroup(slide.id)}
-          onDelete={() => onDeleteSlide(slide.id)}
-        />
-      ))}
+    <div ref={containerRef} className="h-full overflow-y-auto" data-testid="slide-grid-scroll-container">
+      {rowWindow.topSpacerHeight > 0 && (
+        <div aria-hidden="true" style={{ height: rowWindow.topSpacerHeight }} />
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
+        {visibleSlides.map((slide) => (
+          <div key={slide.id} className="h-[320px]">
+            <SlideCard
+              slide={slide}
+              isSelected={selectedIds.has(slide.id)}
+              onSelect={(selected) => onSelectSlide(slide.id, selected)}
+              onStar={() => onStarSlide(slide.id)}
+              onView={() => onViewSlide(slide.id)}
+              onAnalyze={() => onAnalyzeSlide(slide.id)}
+              onAddToGroup={() => onAddToGroup(slide.id)}
+              onDelete={() => onDeleteSlide(slide.id)}
+            />
+          </div>
+        ))}
+      </div>
+
+      {rowWindow.bottomSpacerHeight > 0 && (
+        <div aria-hidden="true" style={{ height: rowWindow.bottomSpacerHeight }} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/slides/SlideTable.tsx
+++ b/frontend/src/components/slides/SlideTable.tsx
@@ -2,11 +2,10 @@
 
 import React from "react";
 import { Badge } from "@/components/ui/Badge";
-import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { cn, truncateText, formatDate } from "@/lib/utils";
 import { useProject } from "@/contexts/ProjectContext";
-import type { SlideInfo, ExtendedSlideInfo, SlideFilters } from "@/types";
+import type { SlideInfo, ExtendedSlideInfo } from "@/types";
 import {
   Star,
   MoreVertical,
@@ -21,6 +20,7 @@ import {
   Circle,
   Minus,
 } from "lucide-react";
+import { getVirtualWindow } from "./virtualization";
 
 interface SlideTableProps {
   slides: (SlideInfo & Partial<ExtendedSlideInfo>)[];
@@ -37,6 +37,9 @@ interface SlideTableProps {
   onSort?: (field: string) => void;
   isLoading?: boolean;
 }
+
+const ROW_HEIGHT = 72;
+const VIRTUALIZE_THRESHOLD = 60;
 
 // Tag colors
 const TAG_COLORS: Record<string, string> = {
@@ -90,7 +93,7 @@ function SortableHeader({
 
 function TableRowSkeleton() {
   return (
-    <tr className="border-b border-gray-100">
+    <tr className="border-b border-gray-100 h-[72px]">
       <td className="py-3 px-4">
         <Skeleton className="h-5 w-5 rounded" />
       </td>
@@ -146,12 +149,12 @@ function SlideRow({
   const menuRef = React.useRef<HTMLDivElement>(null);
 
   // Get display labels from project context
-  const positiveLabel = currentProject.positive_class 
+  const positiveLabel = currentProject.positive_class
     ? currentProject.positive_class.charAt(0).toUpperCase() + currentProject.positive_class.slice(1)
     : "Positive";
-  const negativeLabel = currentProject.classes?.find(c => c !== currentProject.positive_class)
-    ? (currentProject.classes.find(c => c !== currentProject.positive_class) as string).charAt(0).toUpperCase() + 
-      (currentProject.classes.find(c => c !== currentProject.positive_class) as string).slice(1)
+  const negativeLabel = currentProject.classes?.find((c) => c !== currentProject.positive_class)
+    ? (currentProject.classes.find((c) => c !== currentProject.positive_class) as string).charAt(0).toUpperCase() +
+      (currentProject.classes.find((c) => c !== currentProject.positive_class) as string).slice(1)
     : "Negative";
 
   React.useEffect(() => {
@@ -167,12 +170,12 @@ function SlideRow({
   return (
     <tr
       className={cn(
-        "border-b border-gray-100 dark:border-navy-700 hover:bg-gray-50 dark:hover:bg-navy-800/50 transition-colors",
+        "h-[72px] border-b border-gray-100 dark:border-navy-700 hover:bg-gray-50 dark:hover:bg-navy-800/50 transition-colors",
         isSelected && "bg-clinical-50 dark:bg-clinical-900/20"
       )}
     >
       {/* Selection checkbox */}
-      <td className="py-3 px-4">
+      <td className="py-3 px-4 align-middle">
         <button
           onClick={() => onSelect(!isSelected)}
           className="flex items-center justify-center"
@@ -186,7 +189,7 @@ function SlideRow({
       </td>
 
       {/* Name */}
-      <td className="py-3 px-4">
+      <td className="py-3 px-4 align-middle">
         <button
           onClick={onView}
           className="flex items-center gap-2 hover:text-clinical-600 transition-colors"
@@ -201,7 +204,7 @@ function SlideRow({
       </td>
 
       {/* Label */}
-      <td className="py-3 px-4">
+      <td className="py-3 px-4 align-middle">
         {slide.label ? (
           <Badge
             variant={slide.label === "1" ? "success" : "danger"}
@@ -215,14 +218,14 @@ function SlideRow({
       </td>
 
       {/* Tags */}
-      <td className="py-3 px-4">
+      <td className="py-3 px-4 align-middle">
         {slide.tags && slide.tags.length > 0 ? (
-          <div className="flex flex-wrap gap-1">
+          <div className="flex items-center gap-1 overflow-hidden">
             {slide.tags.slice(0, 2).map((tag, idx) => (
               <span
                 key={tag}
                 className={cn(
-                  "px-1.5 py-0.5 text-xs rounded-full",
+                  "px-1.5 py-0.5 text-xs rounded-full whitespace-nowrap",
                   TAG_COLORS[Object.keys(TAG_COLORS)[idx % Object.keys(TAG_COLORS).length]]
                 )}
               >
@@ -230,7 +233,7 @@ function SlideRow({
               </span>
             ))}
             {slide.tags.length > 2 && (
-              <span className="px-1.5 py-0.5 text-xs bg-gray-100 text-gray-500 rounded-full">
+              <span className="px-1.5 py-0.5 text-xs bg-gray-100 text-gray-500 rounded-full whitespace-nowrap">
                 +{slide.tags.length - 2}
               </span>
             )}
@@ -241,21 +244,21 @@ function SlideRow({
       </td>
 
       {/* Patches */}
-      <td className="py-3 px-4">
+      <td className="py-3 px-4 align-middle">
         <span className="text-sm text-gray-600 dark:text-gray-300">
           {slide.numPatches !== undefined ? slide.numPatches.toLocaleString() : "—"}
         </span>
       </td>
 
       {/* Date */}
-      <td className="py-3 px-4">
+      <td className="py-3 px-4 align-middle">
         <span className="text-sm text-gray-500 dark:text-gray-400">
           {formatDate(slide.createdAt)}
         </span>
       </td>
 
       {/* Starred */}
-      <td className="py-3 px-4">
+      <td className="py-3 px-4 align-middle">
         <button
           onClick={onStar}
           className={cn(
@@ -270,7 +273,7 @@ function SlideRow({
       </td>
 
       {/* Actions */}
-      <td className="py-3 px-4">
+      <td className="py-3 px-4 align-middle">
         <div className="relative" ref={menuRef}>
           <button
             onClick={() => setShowMenu(!showMenu)}
@@ -348,9 +351,53 @@ export function SlideTable({
   const allSelected = slides.length > 0 && slides.every((s) => selectedIds.has(s.id));
   const someSelected = slides.some((s) => selectedIds.has(s.id));
 
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = React.useState(0);
+  const [viewportHeight, setViewportHeight] = React.useState(640);
+  const shouldVirtualize = slides.length >= VIRTUALIZE_THRESHOLD;
+
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const updateViewport = () => {
+      setScrollTop(el.scrollTop);
+      setViewportHeight(Math.max(320, el.clientHeight || 0));
+    };
+
+    updateViewport();
+    el.addEventListener("scroll", updateViewport, { passive: true });
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(updateViewport) : null;
+    resizeObserver?.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", updateViewport);
+      resizeObserver?.disconnect();
+    };
+  }, []);
+
+  const windowRange = shouldVirtualize
+    ? getVirtualWindow({
+        itemCount: slides.length,
+        itemHeight: ROW_HEIGHT,
+        viewportHeight,
+        scrollTop,
+        overscan: 8,
+      })
+    : {
+        startIndex: 0,
+        endIndex: slides.length,
+        topSpacerHeight: 0,
+        bottomSpacerHeight: 0,
+      };
+
+  const visibleSlides = slides.slice(windowRange.startIndex, windowRange.endIndex);
+
   if (isLoading && slides.length === 0) {
     return (
-      <div className="overflow-x-auto">
+      <div className="h-full overflow-auto">
         <table className="w-full">
           <thead>
             <tr className="border-b border-gray-200 bg-gray-50">
@@ -390,7 +437,7 @@ export function SlideTable({
 
   if (slides.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="h-full flex flex-col items-center justify-center py-16 text-center">
         <Microscope className="h-16 w-16 text-gray-300 dark:text-gray-600 mb-4" />
         <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No slides found</h3>
         <p className="text-sm text-gray-500 dark:text-gray-400 max-w-sm">
@@ -401,9 +448,9 @@ export function SlideTable({
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div ref={containerRef} className="h-full overflow-auto" data-testid="slide-table-scroll-container">
       <table className="w-full">
-        <thead>
+        <thead className="sticky top-0 z-10">
           <tr className="border-b border-gray-200 dark:border-navy-700 bg-gray-50 dark:bg-navy-900">
             {/* Select all */}
             <th className="py-3 px-4 text-left w-12">
@@ -474,7 +521,13 @@ export function SlideTable({
           </tr>
         </thead>
         <tbody>
-          {slides.map((slide) => (
+          {windowRange.topSpacerHeight > 0 && (
+            <tr aria-hidden="true">
+              <td colSpan={8} style={{ height: windowRange.topSpacerHeight, padding: 0 }} />
+            </tr>
+          )}
+
+          {visibleSlides.map((slide) => (
             <SlideRow
               key={slide.id}
               slide={slide}
@@ -487,6 +540,12 @@ export function SlideTable({
               onDelete={() => onDeleteSlide(slide.id)}
             />
           ))}
+
+          {windowRange.bottomSpacerHeight > 0 && (
+            <tr aria-hidden="true">
+              <td colSpan={8} style={{ height: windowRange.bottomSpacerHeight, padding: 0 }} />
+            </tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/frontend/src/components/slides/__tests__/SlideTable.virtualization.test.tsx
+++ b/frontend/src/components/slides/__tests__/SlideTable.virtualization.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { SlideTable } from "../SlideTable";
+import type { SlideInfo } from "@/types";
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+    ResizeObserverMock as unknown as typeof ResizeObserver;
+});
+
+function makeSlide(i: number): SlideInfo {
+  return {
+    id: `slide-${i}`,
+    filename: `slide-${i}.svs`,
+    dimensions: { width: 1000, height: 800 },
+    magnification: 40,
+    mpp: 0.25,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    numPatches: i,
+    hasEmbeddings: i % 2 === 0,
+  };
+}
+
+describe("SlideTable virtualization", () => {
+  it("renders a windowed subset while preserving row selection behavior", () => {
+    const slides = Array.from({ length: 200 }, (_, i) => makeSlide(i));
+    const onSelectSlide = vi.fn();
+    const onSelectAll = vi.fn();
+
+    const { container } = render(
+      <div style={{ height: 640 }}>
+        <SlideTable
+          slides={slides}
+          selectedIds={new Set()}
+          onSelectSlide={onSelectSlide}
+          onSelectAll={onSelectAll}
+          onStarSlide={vi.fn()}
+          onViewSlide={vi.fn()}
+          onAnalyzeSlide={vi.fn()}
+          onAddToGroup={vi.fn()}
+          onDeleteSlide={vi.fn()}
+          sortBy="date"
+          sortOrder="desc"
+          onSort={vi.fn()}
+        />
+      </div>
+    );
+
+    // Regression guard: far rows should not be in DOM before scrolling.
+    expect(screen.queryByText("slide-199")).toBeNull();
+    expect(screen.getByText("slide-0")).toBeTruthy();
+
+    // Header select-all remains functional.
+    const headerButton = container.querySelector("thead th button") as HTMLButtonElement;
+    fireEvent.click(headerButton);
+    expect(onSelectAll).toHaveBeenCalledWith(true);
+
+    // Per-row select remains functional.
+    const firstRow = screen.getByText("slide-0").closest("tr");
+    expect(firstRow).toBeTruthy();
+    const rowButtons = within(firstRow as HTMLElement).getAllByRole("button");
+    fireEvent.click(rowButtons[0]);
+    expect(onSelectSlide).toHaveBeenCalledWith("slide-0", true);
+
+    // Should only render a small subset (+ spacer rows), not all 200.
+    const renderedRows = container.querySelectorAll("tbody tr").length;
+    expect(renderedRows).toBeLessThan(40);
+  });
+});

--- a/frontend/src/components/slides/__tests__/virtualization.test.ts
+++ b/frontend/src/components/slides/__tests__/virtualization.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getGridColumnCount, getVirtualWindow } from "../virtualization";
+
+describe("slides virtualization helpers", () => {
+  it("returns bounded virtual ranges for large lists", () => {
+    const window = getVirtualWindow({
+      itemCount: 1000,
+      itemHeight: 72,
+      viewportHeight: 360,
+      scrollTop: 720,
+      overscan: 4,
+    });
+
+    expect(window.startIndex).toBe(6);
+    expect(window.endIndex).toBe(19);
+    expect(window.topSpacerHeight).toBe(432);
+    expect(window.bottomSpacerHeight).toBe((1000 - 19) * 72);
+  });
+
+  it("falls back to a safe range when viewport is unavailable", () => {
+    const window = getVirtualWindow({
+      itemCount: 30,
+      itemHeight: 72,
+      viewportHeight: 0,
+      scrollTop: 0,
+    });
+
+    expect(window.startIndex).toBe(0);
+    expect(window.endIndex).toBe(30);
+    expect(window.topSpacerHeight).toBe(0);
+    expect(window.bottomSpacerHeight).toBe(0);
+  });
+
+  it("maps widths to Tailwind grid breakpoints", () => {
+    expect(getGridColumnCount(320)).toBe(1);
+    expect(getGridColumnCount(700)).toBe(2);
+    expect(getGridColumnCount(1100)).toBe(3);
+    expect(getGridColumnCount(1300)).toBe(4);
+    expect(getGridColumnCount(1600)).toBe(5);
+  });
+});

--- a/frontend/src/components/slides/virtualization.ts
+++ b/frontend/src/components/slides/virtualization.ts
@@ -1,0 +1,61 @@
+export interface VirtualWindowInput {
+  itemCount: number;
+  itemHeight: number;
+  viewportHeight: number;
+  scrollTop: number;
+  overscan?: number;
+}
+
+export interface VirtualWindow {
+  startIndex: number;
+  endIndex: number;
+  topSpacerHeight: number;
+  bottomSpacerHeight: number;
+}
+
+/**
+ * Compute a stable virtual window for fixed-height lists.
+ */
+export function getVirtualWindow({
+  itemCount,
+  itemHeight,
+  viewportHeight,
+  scrollTop,
+  overscan = 4,
+}: VirtualWindowInput): VirtualWindow {
+  if (itemCount <= 0 || itemHeight <= 0 || viewportHeight <= 0) {
+    return {
+      startIndex: 0,
+      endIndex: Math.max(0, itemCount),
+      topSpacerHeight: 0,
+      bottomSpacerHeight: 0,
+    };
+  }
+
+  const visibleCount = Math.max(1, Math.ceil(viewportHeight / itemHeight));
+  const rawStart = Math.floor(scrollTop / itemHeight);
+  const startIndex = Math.max(0, rawStart - overscan);
+  const endIndex = Math.min(itemCount, rawStart + visibleCount + overscan);
+
+  const topSpacerHeight = startIndex * itemHeight;
+  const bottomSpacerHeight = Math.max(0, (itemCount - endIndex) * itemHeight);
+
+  return {
+    startIndex,
+    endIndex,
+    topSpacerHeight,
+    bottomSpacerHeight,
+  };
+}
+
+/**
+ * Keep column count aligned with Tailwind breakpoints used by SlideGrid.
+ */
+export function getGridColumnCount(width: number): number {
+  if (!Number.isFinite(width) || width <= 0) return 1;
+  if (width >= 1536) return 5; // 2xl
+  if (width >= 1280) return 4; // xl
+  if (width >= 1024) return 3; // lg
+  if (width >= 640) return 2; // sm
+  return 1;
+}


### PR DESCRIPTION
## Summary
- add fixed-height virtualization primitives for slide list rendering
- virtualize both `/slides` table and grid views while preserving selection, bulk actions, and row/card actions
- debounce filter-driven queries from the filter panel while keeping sort + pagination immediate
- add request de-duplication and cache-backed stale-while-revalidate behavior for slide fetches
- keep refresh and mutation paths force-refreshing network data

## Verification
- `cd frontend && npm run lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx vitest run`

Fixes #104
