### PR TITLE
test(header): lock in theme-aware tokens for top-nav controls

### DIFF
--- a/frontend/src/components/layout/__tests__/headerThemeTokens.test.ts
+++ b/frontend/src/components/layout/__tests__/headerThemeTokens.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression coverage for issues #117 and #118: the top-nav controls listed
+// below must carry both light- and dark-mode tokens. If a future change drops
+// the dark surface or the light text/background, header labels become
+// unreadable in one of the two themes.
+
+const HEADER_SRC = readFileSync(
+  path.resolve(__dirname, "..", "Header.tsx"),
+  "utf8",
+);
+
+const DEMO_SRC = readFileSync(
+  path.resolve(__dirname, "..", "..", "demo", "DemoMode.tsx"),
+  "utf8",
+);
+
+// Find a className string that contains all of the given unique substrings.
+// Searches double-quoted attribute values across the whole source (multi-line
+// supported). Returns the matched string or throws.
+function findClassNameContaining(
+  source: string,
+  needles: string[],
+  label: string,
+): string {
+  const re = /"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    const value = m[1];
+    if (needles.every((needle) => value.includes(needle))) {
+      return value;
+    }
+  }
+  throw new Error(`could not locate className for ${label} (needles: ${needles.join(", ")})`);
+}
+
+function expectThemeAwareSurface(classes: string, controlName: string) {
+  expect(
+    /\bbg-(?:white|sky-\d{2,3})(?:\/\d{1,3})?\b/.test(classes),
+    `${controlName} should declare a light-mode background`,
+  ).toBe(true);
+
+  expect(
+    /\bdark:bg-(?:navy|slate|gray|sky)-\d{2,3}(?:\/\d{1,3})?\b/.test(classes),
+    `${controlName} should declare a dark-mode background`,
+  ).toBe(true);
+
+  expect(
+    /\btext-(?:slate|sky|navy|gray)-\d{2,3}\b/.test(classes),
+    `${controlName} should declare a dark text color for light mode`,
+  ).toBe(true);
+
+  expect(
+    /\bdark:text-(?:gray|slate|white|sky)(?:-\d{2,3})?\b/.test(classes),
+    `${controlName} should declare a light text color for dark mode`,
+  ).toBe(true);
+}
+
+describe("top-nav controls carry theme-aware surfaces (#117, #118)", () => {
+  it("project switcher trigger has light and dark variants", () => {
+    // The trigger button uses a `truncate max-w-[200px]` span inside, and is
+    // the only button with `rounded-lg border border-sky-200 bg-white/90`
+    // that does not have a layout prefix like `hidden lg:flex`. Anchor on
+    // `flex items-center gap-2 px-3 py-1.5`, the button's leading classes.
+    const classes = findClassNameContaining(
+      HEADER_SRC,
+      ["flex items-center gap-2 px-3 py-1.5 rounded-lg", "border-sky-200"],
+      "project switcher trigger",
+    );
+    expectThemeAwareSurface(classes, "project switcher trigger");
+  });
+
+  it("slides nav link has light and dark variants", () => {
+    const classes = findClassNameContaining(
+      HEADER_SRC,
+      ["hidden lg:flex items-center gap-2 rounded-lg", "xl:px-3"],
+      "slides nav link",
+    );
+    // Two nav links share this shape (Slides and Projects); make sure we
+    // got one of them and that it is theme-aware.
+    expectThemeAwareSurface(classes, "slides/projects nav link");
+  });
+
+  it("utility overflow button has light and dark variants", () => {
+    const classes = findClassNameContaining(
+      HEADER_SRC,
+      ["rounded-lg border border-sky-200 bg-white/90 p-2"],
+      "utility overflow button",
+    );
+    expectThemeAwareSurface(classes, "utility overflow button");
+  });
+
+  it("inactive demo-mode toggle has light and dark variants", () => {
+    // The inactive branch lives inside the cn() ternary; locate it by the
+    // ternary structure rather than a className= attribute.
+    const ternary = DEMO_SRC.match(
+      /disabled\s*\?\s*"[^"]+"\s*:\s*isActive\s*\?\s*"[^"]+"\s*:\s*"([^"]+)"/,
+    );
+    expect(
+      ternary,
+      "could not locate DemoToggle inactive className branch",
+    ).toBeTruthy();
+    expectThemeAwareSurface(ternary![1], "inactive demo-mode toggle");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `frontend/src/components/layout/__tests__/headerThemeTokens.test.ts`, a regression test that fails if any of the four controls called out in #117 / #118 ships without paired light- and dark-mode Tailwind tokens.
- Covers: project switcher trigger, Slides nav link (same shape used by Projects nav link), utility overflow button, inactive Demo Mode toggle.
- No new dependencies, no DOM, no changes to `Header.tsx` or `DemoMode.tsx`.

## Why
Both #117 and #118 list "Add/update regression tests for both light and dark theme tokens" in their acceptance criteria. The runtime fixes already landed in `fix: restore light-mode header nav contrast` (a9c1c55e) and `fix: restore dark-mode header nav surfaces` (68858881), but the tests were never added, and the issues remain open. This closes that gap.

## How it works
The test reads `Header.tsx` and `DemoMode.tsx` as source files, locates each control's className string by a unique anchor (e.g. `rounded-lg border border-sky-200 bg-white/90 p-2` for the utility overflow), and asserts the string carries:
- a light-mode background token (`bg-white` / `bg-sky-*`)
- a paired `dark:bg-*` token
- a dark text color for light mode (`text-slate-*` / `text-sky-*` / `text-gray-*`)
- a paired `dark:text-*` token

Anchor strings are deliberately unique and short so a stylistic rewrite that *keeps* the theming intact will still pass, while a rewrite that drops `dark:` variants on any of the four controls will fail.

## Verification
- `npx vitest run` — all 40 tests pass (6 files), including the 4 new cases.
- Negative check: stripping `dark:` tokens from `Header.tsx` causes 3 of the 4 cases to fail as expected; the demo-toggle case lives in `DemoMode.tsx` and stays green until that file is touched.

## Test plan
- [ ] CI runs `vitest` on the frontend and the new file is picked up automatically (existing config globs `src/**/__tests__/*.test.ts`).
- [ ] Reviewer can break either file's theme tokens locally and confirm the test fails with a readable assertion message.

Closes #117
Closes #118